### PR TITLE
Phase 1.8: Canvas layout & Firebase sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,18 @@ SharedDrawingUITests/
 
 ## Development Guidelines
 
+### ⚠️ GitHub Operations — AGENTS READ THIS
+**DO NOT use `gh` CLI for ANY GitHub operation.**
+
+**ALWAYS use GitHub MCP tools:**
+- `mcp__github__create_pull_request` — create/update PRs
+- `mcp__github__update_pull_request` — update existing PRs
+- `mcp__github__issue_read` / `mcp__github__issue_write` — read/write issues
+- `mcp__github__search_code` / `mcp__github__search_issues` — search
+- `mcp__github__get_file_contents` / `mcp__github__create_or_update_file` — file ops
+
+**Why:** `gh` is authenticated to a work account. Personal GitHub access is MCP-only.
+
 ### Testing
 - **Unit tests**: `CanvasViewModel` + `FakeCanvasRepository` (network-free)
 - **Integration tests**: Firebase Emulator Suite (`firebase emulators:start`) for real RTDB behavior
@@ -198,13 +210,6 @@ SharedDrawingUITests/
 - Atomic commits grouped by logical change, not by file
 - PR description references the GitHub issue number
 
-### GitHub Access
-**CRITICAL**: Use GitHub MCP tools exclusively, never use `gh` CLI.
-- For creating/updating PRs, use `mcp__github__create_pull_request` / `mcp__github__update_pull_request`
-- For file operations, use `mcp__github__create_or_update_file` / `mcp__github__get_file_contents`
-- For issues, use `mcp__github__issue_read` / `mcp__github__issue_write`
-- For code search, use `mcp__github__search_code` / `mcp__github__search_issues`
-- Reason: The `gh` CLI is authenticated to a work account; personal account is via MCP tokens only
 
 ---
 

--- a/SharedDrawing/ContentView.swift
+++ b/SharedDrawing/ContentView.swift
@@ -4,12 +4,7 @@ struct ContentView: View {
     let authService: AuthService
 
     var body: some View {
-        let repository = FirebaseCanvasRepository()
-        CanvasView(
-            canvasId: "test-canvas",
-            repository: repository,
-            authService: authService
-        )
+        CanvasIDView()
     }
 }
 

--- a/SharedDrawing/Features/CanvasList/CanvasIDView.swift
+++ b/SharedDrawing/Features/CanvasList/CanvasIDView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct CanvasIDView: View {
+    @State private var enteredID = ""
+    @State private var selectedCanvasID: String?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("SharedDrawing")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Canvas ID")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                    TextField("Enter canvas ID", text: $enteredID)
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                }
+
+                HStack(spacing: 12) {
+                    Button(action: { selectedCanvasID = generateRandomID() }) {
+                        Text("Create")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button(action: { selectedCanvasID = enteredID.trimmingCharacters(in: .whitespaces) }) {
+                        Text("Join")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(enteredID.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+
+                Spacer()
+            }
+            .padding()
+            .navigationDestination(isPresented: .constant(selectedCanvasID != nil)) {
+                if let canvasID = selectedCanvasID {
+                    CanvasView(
+                        canvasId: canvasID,
+                        repository: FirebaseCanvasRepository(),
+                        authService: AuthService()
+                    )
+                    .navigationBarBackButtonHidden()
+                }
+            }
+        }
+    }
+
+    private func generateRandomID() -> String {
+        let characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        return String((0..<5).map { _ in characters.randomElement()! })
+    }
+}
+
+#Preview {
+    CanvasIDView()
+}


### PR DESCRIPTION
## Summary

- **Fixed canvas layout**: Canvas ID and color picker now respect safe area, no longer hidden behind status bar
- **Simplified canvas ID sheet**: Unified `canvasId` binding (no separate `enteredID`), auto-dismiss buttons
- **Canvas switching**: When ID changes, ViewModel clears strokes and re-syncs from Firebase
- **Firebase integration**: Real-time stroke sync with debug logging and error handling
- **Security rules**: MVP rules (open access) for testing; tighten later in Phase 2
- **Launch screen**: Configured launch screen to display properly with safe area handling

## Key Changes

### CanvasView.swift
- Fixed layout: Canvas extends to edges, controls in safe area via `.safeAreaInset(edge: .top)`
- Restored full touch input logic that was previously stripped
- Added `.onChange(of: canvasId)` to handle canvas switching
- Debug logging for Firebase write attempts

### CanvasViewModel.swift
- Added `switchToCanvas()` method to handle ID changes
- Cancels old listener, clears strokes, sets up new listener on canvas switch

### ChangeCanvasIDSheet.swift
- Removed separate `enteredID` binding, now uses `canvasId` directly
- "Generate" button creates new ID inline
- "Open" button closes sheet and triggers sync
- Removed unnecessary "Done" button

### Info.plist & RTDB_SECURITY_RULES.json
- Added launch screen configuration
- Firebase Realtime Database rules for MVP

## Test Plan

- [ ] Draw on canvas, verify strokes appear instantly and sync to Firebase
- [ ] Check Firebase console → Data tab for `/v2/canvases/{id}/strokes/` entries
- [ ] Generate new canvas ID, verify old strokes clear and canvas reloads
- [ ] Join existing canvas by entering ID, verify strokes load from Firebase
- [ ] Tap canvas ID to open sheet, verify layout doesn't overlap with status bar
- [ ] Test color picker with multiple colors
- [ ] Manual two-device test: draw on one, watch sync on another

## Known Issues

- Security rules are wide open (MVP only) — will tighten in Phase 2
- App Delegate swizzler warning can be ignored (Firebase SDK issue)

## Closes
#57