### PR TITLE
Phase 2.1: Firestore-backed my canvases list

### DIFF
--- a/SharedDrawing/ContentView.swift
+++ b/SharedDrawing/ContentView.swift
@@ -1,21 +1,18 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var currentCanvasID: String = UUID().uuidString.prefix(5).lowercased()
-
     let authService: AuthService
 
     var body: some View {
-        CanvasView(
-            canvasId: $currentCanvasID,
-            repository: FirebaseCanvasRepository(),
-            authService: authService
-        )
-    }
-
-    private func generateRandomID() -> String {
-        let characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        return String((0..<5).map { _ in characters.randomElement()! })
+        if let userId = authService.currentUserID {
+            MyCanvasesView(
+                userId: userId,
+                repository: FirebaseCanvasRepository(),
+                authService: authService
+            )
+        } else {
+            ProgressView("Signing in...")
+        }
     }
 }
 

--- a/SharedDrawing/Core/Networking/FirestoreService.swift
+++ b/SharedDrawing/Core/Networking/FirestoreService.swift
@@ -1,0 +1,59 @@
+import Foundation
+import FirebaseFirestore
+
+class FirestoreService {
+    static let shared = FirestoreService()
+    private let db = Firestore.firestore()
+
+    func saveCanvas(id: String, name: String, userId: String) async throws {
+        let ref = db.collection("users").document(userId).collection("canvases").document(id)
+        try await ref.setData([
+            "canvasId": id,
+            "name": name,
+            "createdAt": Timestamp(date: Date()),
+            "lastActivityAt": Timestamp(date: Date())
+        ], merge: true)
+    }
+
+    func updateLastActivity(canvasId: String, userId: String) async throws {
+        let ref = db.collection("users").document(userId).collection("canvases").document(canvasId)
+        try await ref.updateData([
+            "lastActivityAt": Timestamp(date: Date())
+        ])
+    }
+
+    func getCanvases(userId: String) async throws -> [CanvasMetadata] {
+        let snapshot = try await db.collection("users")
+            .document(userId)
+            .collection("canvases")
+            .order(by: "lastActivityAt", descending: true)
+            .getDocuments()
+
+        return snapshot.documents.compactMap { doc in
+            try? doc.data(as: CanvasMetadata.self)
+        }
+    }
+
+    func listenToCanvases(userId: String, completion: @escaping ([CanvasMetadata]) -> Void) -> ListenerRegistration {
+        return db.collection("users")
+            .document(userId)
+            .collection("canvases")
+            .order(by: "lastActivityAt", descending: true)
+            .addSnapshotListener { snapshot, _ in
+                guard let docs = snapshot?.documents else { return }
+                let canvases = docs.compactMap { try? $0.data(as: CanvasMetadata.self) }
+                completion(canvases)
+            }
+    }
+}
+
+struct CanvasMetadata: Codable {
+    @DocumentID var id: String?
+    let canvasId: String
+    let name: String
+    let createdAt: Timestamp
+    let lastActivityAt: Timestamp
+
+    var createdDate: Date { createdAt.dateValue() }
+    var lastActivityDate: Date { lastActivityAt.dateValue() }
+}

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -7,19 +7,20 @@ struct CanvasView: View {
     @State private var lastUpdateTime: Date?
     @State private var showCanvasIDSheet = false
     @State private var showClearConfirmation = false
+    @State private var canvasId: String
 
-    @Binding var canvasId: String
     let repository: CanvasRepository
     let authService: AuthService
 
     private let throttleInterval: TimeInterval = 0.05  // ~50ms throttle for live updates
 
-    init(canvasId: Binding<String>, repository: CanvasRepository, authService: AuthService) {
-        self._canvasId = canvasId
+    init(canvasId: String, repository: CanvasRepository, authService: AuthService) {
         self.repository = repository
         self.authService = authService
+        let initialCanvasId = canvasId
+        self._canvasId = State(initialValue: initialCanvasId)
         self._viewModel = State(initialValue: CanvasViewModel(
-            canvasId: canvasId.wrappedValue,
+            canvasId: initialCanvasId,
             repository: repository,
             authService: authService
         ))

--- a/SharedDrawing/Features/Canvas/CanvasViewModel.swift
+++ b/SharedDrawing/Features/Canvas/CanvasViewModel.swift
@@ -19,6 +19,18 @@ class CanvasViewModel {
         self.repository = repository
         self.authService = authService
         setupStrokeListener()
+        saveCanvasMetadata()
+    }
+
+    private func saveCanvasMetadata() {
+        guard let userId = authService.currentUserID else { return }
+        Task {
+            try? await FirestoreService.shared.saveCanvas(
+                id: canvasId,
+                name: canvasId,
+                userId: userId
+            )
+        }
     }
 
     func switchToCanvas(_ newCanvasId: String) {
@@ -74,6 +86,13 @@ class CanvasViewModel {
         do {
             try await repository.addStroke(finalStroke, to: canvasId)
             undoStack.push(finalStroke)
+
+            if let userId = authService.currentUserID {
+                try? await FirestoreService.shared.updateLastActivity(
+                    canvasId: canvasId,
+                    userId: userId
+                )
+            }
         } catch {
             print("Error submitting stroke: \(error)")
         }

--- a/SharedDrawing/Features/CanvasList/CanvasIDView.swift
+++ b/SharedDrawing/Features/CanvasList/CanvasIDView.swift
@@ -3,13 +3,13 @@ import SwiftUI
 struct CanvasIDView: View {
     @State private var enteredID = ""
     @State private var selectedCanvasID: String?
+    @Environment(\.dismiss) var dismiss
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 20) {
-                Text("SharedDrawing")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
+                Text("Create or Join Canvas")
+                    .font(.headline)
 
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Canvas ID")
@@ -42,7 +42,7 @@ struct CanvasIDView: View {
             .navigationDestination(isPresented: .constant(selectedCanvasID != nil)) {
                 if let canvasID = selectedCanvasID {
                     CanvasView(
-                        canvasId: .constant(canvasID),
+                        canvasId: canvasID,
                         repository: FirebaseCanvasRepository(),
                         authService: AuthService()
                     )

--- a/SharedDrawing/Features/CanvasList/MyCanvasesView.swift
+++ b/SharedDrawing/Features/CanvasList/MyCanvasesView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+@Observable
+class MyCanvasesViewModel {
+    var canvases: [CanvasMetadata] = []
+    var isLoading = false
+    private var listener: ListenerRegistration?
+
+    func loadCanvases(userId: String) {
+        isLoading = true
+        listener = FirestoreService.shared.listenToCanvases(userId: userId) { [weak self] canvases in
+            self?.canvases = canvases
+            self?.isLoading = false
+        }
+    }
+
+    deinit {
+        listener?.remove()
+    }
+}
+
+struct MyCanvasesView: View {
+    @State private var viewModel = MyCanvasesViewModel()
+    @State private var selectedCanvasId: String?
+    let userId: String
+    let repository: CanvasRepository
+    let authService: AuthService
+
+    var body: some View {
+        NavigationStack {
+            VStack {
+                if viewModel.isLoading {
+                    ProgressView()
+                } else if viewModel.canvases.isEmpty {
+                    VStack(spacing: 16) {
+                        Text("No canvases yet")
+                            .font(.headline)
+                            .foregroundColor(.gray)
+                        Text("Create or join a canvas to get started")
+                            .font(.subheadline)
+                            .foregroundColor(.gray)
+                    }
+                    .frame(maxHeight: .infinity, alignment: .center)
+                } else {
+                    List {
+                        ForEach(viewModel.canvases, id: \.id) { canvas in
+                            NavigationLink(value: canvas.canvasId) {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(canvas.name)
+                                        .font(.headline)
+                                    HStack(spacing: 12) {
+                                        Text("ID: \(canvas.canvasId)")
+                                            .font(.caption)
+                                            .monospaced()
+                                            .foregroundColor(.gray)
+                                        Spacer()
+                                        Text(formatDate(canvas.lastActivityDate))
+                                            .font(.caption)
+                                            .foregroundColor(.gray)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle("My Canvases")
+            .navigationDestination(isPresented: .constant(selectedCanvasId != nil)) {
+                if let canvasId = selectedCanvasId {
+                    CanvasView(
+                        canvasId: canvasId,
+                        repository: repository,
+                        authService: authService
+                    )
+                    .navigationBarBackButtonHidden()
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    NavigationLink(destination: CanvasIDView()) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+        }
+        .onAppear {
+            viewModel.loadCanvases(userId: userId)
+        }
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+#Preview {
+    MyCanvasesView(
+        userId: "test-user",
+        repository: FakeCanvasRepository(),
+        authService: AuthService()
+    )
+}


### PR DESCRIPTION
## Summary

Implement persistent cross-device canvas list using Firestore. Users can now see all canvases they've created/joined, sorted by recent activity.

## Features

- **My Canvases view**: List all user's canvases with metadata
- **Cross-device sync**: Canvas list persists across app restarts and devices
- **Activity tracking**: Canvases sorted by lastActivityAt
- **Auto-save metadata**: Canvas added to Firestore when created/joined

## Implementation

- **FirestoreService**: Manage canvas metadata in `/users/{uid}/canvases`
- **MyCanvasesView**: SwiftUI view listing canvases from Firestore listener
- **ContentView**: Entry point now shows My Canvases instead of random canvas
- **CanvasViewModel**: Save canvas on init, update lastActivityAt on stroke submission
- **CanvasView**: Refactored to accept String canvasId (not Binding)

## Data Structure

```
/users/{uid}/canvases/{canvasId}/
  - canvasId: string
  - name: string (canvas ID)
  - createdAt: timestamp
  - lastActivityAt: timestamp
```

## Test Plan

- [ ] My Canvases view loads and displays user's canvases
- [ ] Create new canvas from My Canvases, it appears in list
- [ ] Join existing canvas from My Canvases, it appears in list
- [ ] Canvases sorted by recent activity
- [ ] lastActivityAt updates when drawing strokes
- [ ] Test on fresh install (no canvases) shows empty state
- [ ] Refresh/reopen app, canvases persist

## Closes
#70