### PR TITLE
Issue #92: Update lastActivityAt on stroke submit

### DIFF
--- a/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
+++ b/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
@@ -45,6 +45,10 @@ class FirebaseCanvasRepository: CanvasRepository {
         print("📤 Adding stroke \(stroke.id) to canvas \(canvasId): \(strokeData.count) fields")
         try await strokeRef.setValue(strokeData)
         print("✅ Stroke \(stroke.id) added successfully")
+
+        // Update canvas lastActivityAt for retention policy
+        let metaRef = database.child("v2/canvases").child(canvasId).child("meta").child("lastActivityAt")
+        try await metaRef.setValue(ServerValue.timestamp())
     }
 
     func updateStroke(_ stroke: Stroke, in canvasId: String) async throws {


### PR DESCRIPTION
## Summary
Update `lastActivityAt` timestamp on `v2/canvases/{canvasId}/meta` after each stroke submission.

## Changes
- In `FirebaseCanvasRepository.addStroke()`, after successfully adding a stroke, update the canvas meta's `lastActivityAt` with the current server timestamp
- Uses `ServerValue.timestamp()` for consistency with Firebase

## Related
Closes #92
Works with shareddrawingweb retention policy job