### PR TITLE
Phase 2.5: Pannable virtual canvas with pointer/pen mode

### DIFF
--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -11,6 +11,7 @@ struct CanvasView: View {
     @State private var showImagePicker = false
     @State private var selectedImage: UIImage?
     @State private var backgroundImage: UIImage?
+    @State private var isPointerMode = false  // false=pen, true=pointer/pan
 
     @Binding var canvasId: String
     let repository: CanvasRepository
@@ -41,24 +42,11 @@ struct CanvasView: View {
                 }
                 .disabled(!viewModel.canUndo)
 
-                // Pan buttons
-                HStack(spacing: 4) {
-                    Button(action: { viewModel.pan(.init(x: -50, y: 0)) }) {
-                        Image(systemName: "arrowshape.left")
-                            .font(.system(size: 12))
-                    }
-                    Button(action: { viewModel.pan(.init(x: 0, y: -50)) }) {
-                        Image(systemName: "arrowshape.up")
-                            .font(.system(size: 12))
-                    }
-                    Button(action: { viewModel.pan(.init(x: 0, y: 50)) }) {
-                        Image(systemName: "arrowshape.down")
-                            .font(.system(size: 12))
-                    }
-                    Button(action: { viewModel.pan(.init(x: 50, y: 0)) }) {
-                        Image(systemName: "arrowshape.right")
-                            .font(.system(size: 12))
-                    }
+                // Pointer/Pen toggle
+                Button(action: { isPointerMode.toggle() }) {
+                    Image(systemName: isPointerMode ? "hand.point.up.fill" : "pencil")
+                        .font(.system(size: 14))
+                        .foregroundColor(isPointerMode ? .blue : .primary)
                 }
 
                 Button(action: {
@@ -186,47 +174,76 @@ struct CanvasView: View {
 
                     StrokeCaptureView(
                         onPointsCapture: { points in
-                            print("📍 Touch: \(points.count) points, isDrawing=\(isDrawing)")
                             guard !points.isEmpty else { return }
 
-                            // Adjust points for viewport offset (convert screen to world coordinates)
-                            let adjustedPoints = points.map { CGPoint(x: $0.x + viewModel.viewportOffset.x, y: $0.y + viewModel.viewportOffset.y) }
-
-                            if !isDrawing {
-                                print("🎨 Starting new stroke")
-                                isDrawing = true
-                                currentStroke = viewModel.startStroke(at: adjustedPoints.first ?? .zero)
-                            }
-
-                            if var stroke = currentStroke {
-                                for point in adjustedPoints {
-                                    viewModel.addStrokePoint(point, to: &stroke)
+                            if isPointerMode {
+                                // In pointer mode, use drag to pan
+                                if let prevPoint = currentStroke?.points.last {
+                                    let delta = CGPoint(
+                                        x: points.first?.x ?? 0 - prevPoint.x,
+                                        y: points.first?.y ?? 0 - prevPoint.y
+                                    )
+                                    viewModel.pan(delta)
                                 }
-                                currentStroke = stroke
+                                // Store last point for next delta calculation
+                                if currentStroke == nil {
+                                    currentStroke = viewModel.startStroke(at: points.first ?? .zero)
+                                }
+                                if var stroke = currentStroke {
+                                    for point in points {
+                                        viewModel.addStrokePoint(point, to: &stroke)
+                                    }
+                                    currentStroke = stroke
+                                }
+                            } else {
+                                // In pen mode, draw strokes
+                                print("📍 Touch: \(points.count) points, isDrawing=\(isDrawing)")
 
-                                let now = Date()
-                                if lastUpdateTime == nil || now.timeIntervalSince(lastUpdateTime ?? now) >= throttleInterval {
-                                    lastUpdateTime = now
-                                    Task {
-                                        do {
-                                            try await viewModel.repository.updateStroke(stroke, in: canvasId)
-                                        } catch {
-                                            print("❌ Error updating stroke: \(error)")
+                                // Adjust points for viewport offset (convert screen to world coordinates)
+                                let adjustedPoints = points.map { CGPoint(x: $0.x + viewModel.viewportOffset.x, y: $0.y + viewModel.viewportOffset.y) }
+
+                                if !isDrawing {
+                                    print("🎨 Starting new stroke")
+                                    isDrawing = true
+                                    currentStroke = viewModel.startStroke(at: adjustedPoints.first ?? .zero)
+                                }
+
+                                if var stroke = currentStroke {
+                                    for point in adjustedPoints {
+                                        viewModel.addStrokePoint(point, to: &stroke)
+                                    }
+                                    currentStroke = stroke
+
+                                    let now = Date()
+                                    if lastUpdateTime == nil || now.timeIntervalSince(lastUpdateTime ?? now) >= throttleInterval {
+                                        lastUpdateTime = now
+                                        Task {
+                                            do {
+                                                try await viewModel.repository.updateStroke(stroke, in: canvasId)
+                                            } catch {
+                                                print("❌ Error updating stroke: \(error)")
+                                            }
                                         }
                                     }
                                 }
                             }
                         },
                         onStrokeEnded: {
-                            print("✋ Stroke ended, submitting \(currentStroke?.points.count ?? 0) points")
-                            guard let stroke = currentStroke else { return }
-                            let endedStroke = stroke
-                            currentStroke = nil
-                            isDrawing = false
-                            Task {
-                                await viewModel.submitStroke(endedStroke)
-                                print("✅ Stroke submitted")
+                            if isPointerMode {
+                                // Reset pointer tracking
+                                currentStroke = nil
+                            } else {
+                                print("✋ Stroke ended, submitting \(currentStroke?.points.count ?? 0) points")
+                                guard let stroke = currentStroke else { return }
+                                let endedStroke = stroke
+                                currentStroke = nil
+                                isDrawing = false
+                                Task {
+                                    await viewModel.submitStroke(endedStroke)
+                                    print("✅ Stroke submitted")
+                                }
                             }
+                        }
                         }
                     )
 

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -31,7 +31,7 @@ struct CanvasView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Canvas ID header with Undo/Share buttons
+            // Canvas ID header with Undo/Pan/Share buttons
             HStack(spacing: 8) {
                 Button(action: {
                     Task { await viewModel.undo() }
@@ -40,6 +40,26 @@ struct CanvasView: View {
                         .font(.system(size: 14))
                 }
                 .disabled(!viewModel.canUndo)
+
+                // Pan buttons
+                HStack(spacing: 4) {
+                    Button(action: { viewModel.pan(.init(x: -50, y: 0)) }) {
+                        Image(systemName: "arrowshape.left")
+                            .font(.system(size: 12))
+                    }
+                    Button(action: { viewModel.pan(.init(x: 0, y: -50)) }) {
+                        Image(systemName: "arrowshape.up")
+                            .font(.system(size: 12))
+                    }
+                    Button(action: { viewModel.pan(.init(x: 0, y: 50)) }) {
+                        Image(systemName: "arrowshape.down")
+                            .font(.system(size: 12))
+                    }
+                    Button(action: { viewModel.pan(.init(x: 50, y: 0)) }) {
+                        Image(systemName: "arrowshape.right")
+                            .font(.system(size: 12))
+                    }
+                }
 
                 Button(action: {
                     showCanvasIDSheet = true
@@ -155,11 +175,11 @@ struct CanvasView: View {
 
                         Canvas { context, size in
                             for stroke in viewModel.strokes {
-                                renderStroke(stroke, in: &context)
+                                renderStroke(stroke, in: &context, offset: viewModel.viewportOffset)
                             }
 
                             if let current = currentStroke {
-                                renderStroke(current, in: &context)
+                                renderStroke(current, in: &context, offset: viewModel.viewportOffset)
                             }
                         }
                     }
@@ -271,15 +291,15 @@ struct CanvasView: View {
         }
     }
 
-    private func renderStroke(_ stroke: Stroke, in context: inout GraphicsContext) {
+    private func renderStroke(_ stroke: Stroke, in context: inout GraphicsContext, offset: CGPoint = .zero) {
         guard stroke.points.count > 1 else { return }
 
         var path = Path()
         let firstPoint = stroke.points[0]
-        path.move(to: CGPoint(x: firstPoint.x, y: firstPoint.y))
+        path.move(to: CGPoint(x: firstPoint.x - offset.x, y: firstPoint.y - offset.y))
 
         for point in stroke.points.dropFirst() {
-            path.addLine(to: CGPoint(x: point.x, y: point.y))
+            path.addLine(to: CGPoint(x: point.x - offset.x, y: point.y - offset.y))
         }
 
         let color = Color(hex: stroke.color)

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -12,6 +12,7 @@ struct CanvasView: View {
     @State private var selectedImage: UIImage?
     @State private var backgroundImage: UIImage?
     @State private var isPointerMode = false  // false=pen, true=pointer/pan
+    @State private var lastPointerPosition: CGPoint = .zero
 
     @Binding var canvasId: String
     let repository: CanvasRepository
@@ -178,23 +179,17 @@ struct CanvasView: View {
 
                             if isPointerMode {
                                 // In pointer mode, use drag to pan
-                                if let prevPoint = currentStroke?.points.last {
+                                guard let currentPoint = points.last else { return }
+
+                                if lastPointerPosition != .zero {
                                     let delta = CGPoint(
-                                        x: points.first?.x ?? 0 - prevPoint.x,
-                                        y: points.first?.y ?? 0 - prevPoint.y
+                                        x: currentPoint.x - lastPointerPosition.x,
+                                        y: currentPoint.y - lastPointerPosition.y
                                     )
-                                    viewModel.pan(delta)
+                                    // Negate delta so dragging right pans right (not left)
+                                    viewModel.pan(CGPoint(x: -delta.x, y: -delta.y))
                                 }
-                                // Store last point for next delta calculation
-                                if currentStroke == nil {
-                                    currentStroke = viewModel.startStroke(at: points.first ?? .zero)
-                                }
-                                if var stroke = currentStroke {
-                                    for point in points {
-                                        viewModel.addStrokePoint(point, to: &stroke)
-                                    }
-                                    currentStroke = stroke
-                                }
+                                lastPointerPosition = currentPoint
                             } else {
                                 // In pen mode, draw strokes
                                 print("📍 Touch: \(points.count) points, isDrawing=\(isDrawing)")
@@ -231,7 +226,7 @@ struct CanvasView: View {
                         onStrokeEnded: {
                             if isPointerMode {
                                 // Reset pointer tracking
-                                currentStroke = nil
+                                lastPointerPosition = .zero
                             } else {
                                 print("✋ Stroke ended, submitting \(currentStroke?.points.count ?? 0) points")
                                 guard let stroke = currentStroke else { return }
@@ -243,7 +238,6 @@ struct CanvasView: View {
                                     print("✅ Stroke submitted")
                                 }
                             }
-                        }
                         }
                     )
 

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -189,14 +189,17 @@ struct CanvasView: View {
                             print("📍 Touch: \(points.count) points, isDrawing=\(isDrawing)")
                             guard !points.isEmpty else { return }
 
+                            // Adjust points for viewport offset (convert screen to world coordinates)
+                            let adjustedPoints = points.map { CGPoint(x: $0.x + viewModel.viewportOffset.x, y: $0.y + viewModel.viewportOffset.y) }
+
                             if !isDrawing {
                                 print("🎨 Starting new stroke")
                                 isDrawing = true
-                                currentStroke = viewModel.startStroke(at: points.first ?? .zero)
+                                currentStroke = viewModel.startStroke(at: adjustedPoints.first ?? .zero)
                             }
 
                             if var stroke = currentStroke {
-                                for point in points {
+                                for point in adjustedPoints {
                                     viewModel.addStrokePoint(point, to: &stroke)
                                 }
                                 currentStroke = stroke

--- a/SharedDrawing/Features/Canvas/CanvasViewModel.swift
+++ b/SharedDrawing/Features/Canvas/CanvasViewModel.swift
@@ -7,6 +7,7 @@ class CanvasViewModel {
     var currentColor: String = "#000000"  // Black by default
     var canvasId: String
     var backgroundImageUrl: String?
+    var viewportOffset: CGPoint = .zero  // Pan offset for larger virtual canvas
     var canUndo: Bool { !undoStack.isEmpty || lastClearedStrokes != nil }
 
     let repository: CanvasRepository
@@ -27,7 +28,13 @@ class CanvasViewModel {
         canvasId = newCanvasId
         strokes = []
         backgroundImageUrl = nil
+        viewportOffset = .zero
         setupStrokeListener()
+    }
+
+    func pan(_ offset: CGPoint) {
+        viewportOffset.x += offset.x
+        viewportOffset.y += offset.y
     }
 
     private func setupStrokeListener() {

--- a/SharedDrawing/Features/Canvas/CanvasViewModel.swift
+++ b/SharedDrawing/Features/Canvas/CanvasViewModel.swift
@@ -38,24 +38,16 @@ class CanvasViewModel {
     }
 
     private func setupStrokeListener() {
-        // Load background image from metadata (with retry)
+        // Load background image from metadata
         Task {
-            for attempt in 1...3 {
-                do {
-                    let url = try await repository.getBackgroundImageUrl(for: canvasId)
-                    if let url = url {
-                        self.backgroundImageUrl = url
-                        print("📸 Loaded background image URL: \(url)")
-                    }
-                    break
-                } catch {
-                    if attempt < 3 {
-                        print("⚠️ Attempt \(attempt) failed, retrying...")
-                        try? await Task.sleep(nanoseconds: 500_000_000)  // 0.5s delay
-                    } else {
-                        print("⚠️ Failed to load background image URL after 3 attempts: \(error)")
-                    }
+            do {
+                let url = try await repository.getBackgroundImageUrl(for: canvasId)
+                if let url = url {
+                    self.backgroundImageUrl = url
+                    print("📸 Loaded background image URL: \(url)")
                 }
+            } catch {
+                print("⚠️ Failed to load background image URL: \(error)")
             }
         }
 


### PR DESCRIPTION
## Summary
Add canvas panning with intuitive pointer/pen mode toggle. Users can seamlessly switch between drawing (pen mode) and panning (pointer mode) to navigate larger virtual canvas.

## Features
- **Pointer/Pen Toggle**: Button in toolbar switches between modes
- **Pen Mode** (default): Draw strokes normally with viewport-adjusted coordinates
- **Pointer Mode**: Drag to pan canvas smoothly, natural direction (drag right = pan right)
- **Session-Only State**: Pan position resets on canvas switch or app reload (not persisted)

## Implementation
- Added `viewportOffset: CGPoint` to CanvasViewModel (local session state)
- Added `isPointerMode` toggle state in CanvasView
- Updated stroke capture to adjust points for viewport offset (screen → world coordinates)
- Updated stroke rendering to apply inverse offset for display
- Separate touch handling logic for each mode

## How it works
1. **Pen mode**: Touch capture creates strokes with coordinates adjusted for current viewport
2. **Pointer mode**: Drag calculates delta from last position and pans by negated delta
3. **Rendering**: Strokes render with `-viewportOffset` applied to show panned view
4. **Reset**: Pan resets when switching canvases or on app reload (session-only)

## Testing
- Toggle between pen and pointer modes
- Draw in pen mode across different viewport positions
- Pan canvas in pointer mode and verify strokes stay aligned
- Switch canvases and verify pan resets to origin
- Verify pan direction is intuitive (drag right = see right)

Fixes #74