### PR TITLE
[Phase 2.7] Image-based coordinate system alignment with auto-fit zoom (#95)

### DIFF
--- a/SharedDrawing/Core/Models/CanvasMeta.swift
+++ b/SharedDrawing/Core/Models/CanvasMeta.swift
@@ -5,4 +5,6 @@ struct CanvasMeta: Codable {
     let createdBy: String
     let createdAt: TimeInterval
     let lastActivityAt: TimeInterval
+    let imageWidth: Double?
+    let imageHeight: Double?
 }

--- a/SharedDrawing/Core/Networking/CanvasRepository.swift
+++ b/SharedDrawing/Core/Networking/CanvasRepository.swift
@@ -11,7 +11,9 @@ protocol CanvasRepository {
     func addStroke(_ stroke: Stroke, to canvasId: String) async throws
     func updateStroke(_ stroke: Stroke, in canvasId: String) async throws
     func removeStroke(id: String, from canvasId: String) async throws
-    func updateBackgroundImageUrl(_ url: String, for canvasId: String) async throws
+    func updateBackgroundImageUrl(_ url: String, width: Double?, height: Double?, for canvasId: String) async throws
     func getBackgroundImageUrl(for canvasId: String) async throws -> String?
+    func getBackgroundImageDimensions(for canvasId: String) async throws -> CGSize?
+    func updateBackgroundImageDimensions(width: Double, height: Double, for canvasId: String) async throws
     func removeBackgroundImage(for canvasId: String) async throws
 }

--- a/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
+++ b/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
@@ -63,9 +63,16 @@ class FirebaseCanvasRepository: CanvasRepository {
         try await strokeRef.removeValue()
     }
 
-    func updateBackgroundImageUrl(_ url: String, for canvasId: String) async throws {
-        let metaRef = database.child("v2/canvases").child(canvasId).child("meta").child("backgroundImageUrl")
-        try await metaRef.setValue(url)
+    func updateBackgroundImageUrl(_ url: String, width: Double?, height: Double?, for canvasId: String) async throws {
+        let metaRef = database.child("v2/canvases").child(canvasId).child("meta")
+        var updates: [String: Any] = ["backgroundImageUrl": url]
+        if let width = width {
+            updates["imageWidth"] = width
+        }
+        if let height = height {
+            updates["imageHeight"] = height
+        }
+        try await metaRef.updateChildValues(updates)
     }
 
     func getBackgroundImageUrl(for canvasId: String) async throws -> String? {
@@ -74,10 +81,26 @@ class FirebaseCanvasRepository: CanvasRepository {
         return snapshot.value as? String
     }
 
+    func getBackgroundImageDimensions(for canvasId: String) async throws -> CGSize? {
+        let metaRef = database.child("v2/canvases").child(canvasId).child("meta")
+        let snapshot = try await metaRef.getData()
+        guard let dict = snapshot.value as? [String: Any],
+              let width = dict["imageWidth"] as? Double,
+              let height = dict["imageHeight"] as? Double else {
+            return nil
+        }
+        return CGSize(width: width, height: height)
+    }
+
+    func updateBackgroundImageDimensions(width: Double, height: Double, for canvasId: String) async throws {
+        let metaRef = database.child("v2/canvases").child(canvasId).child("meta")
+        try await metaRef.updateChildValues(["imageWidth": width, "imageHeight": height])
+    }
+
     func removeBackgroundImage(for canvasId: String) async throws {
-        let metaRef = database.child("v2/canvases").child(canvasId).child("meta").child("backgroundImageUrl")
-        try await metaRef.removeValue()
-        print("🗑️ Dropped backgroundImageUrl node for canvas \(canvasId)")
+        let metaRef = database.child("v2/canvases").child(canvasId).child("meta")
+        try await metaRef.updateChildValues(["backgroundImageUrl": NSNull(), "imageWidth": NSNull(), "imageHeight": NSNull()])
+        print("🗑️ Dropped backgroundImageUrl, imageWidth, and imageHeight nodes for canvas \(canvasId)")
     }
 
     // MARK: - Private Helpers

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -138,7 +138,9 @@ struct CanvasView: View {
                         )
 
                         let signedURL = try await uploader.uploadImage(jpegData, canvasId: canvasId, userId: authService.currentUserID ?? "anonymous")
-                        try await viewModel.updateBackgroundImage(signedURL)
+                        let width = Double(newImage.size.width)
+                        let height = Double(newImage.size.height)
+                        try await viewModel.updateBackgroundImage(signedURL, width: width, height: height)
                         print("✅ Background image uploaded and stored: \(signedURL)")
                     } catch {
                         print("❌ Error uploading image: \(error)")
@@ -155,6 +157,10 @@ struct CanvasView: View {
                                     self.backgroundImage = uiImage
                                     print("✅ Background image loaded from URL")
                                 }
+                                // Backfill dimensions if not already set
+                                let width = Double(uiImage.size.width)
+                                let height = Double(uiImage.size.height)
+                                await viewModel.backfillImageDimensionsIfNeeded(width: width, height: height)
                             }
                         } catch {
                             print("❌ Failed to load background image from URL: \(error)")
@@ -173,21 +179,29 @@ struct CanvasView: View {
                 ZStack {
                     Color.white
 
-                    if let bgImage = backgroundImage {
-                        Image(uiImage: bgImage)
-                            .resizable()
-                            .ignoresSafeArea()
-                    }
-
                     Canvas { context, size in
-                        let transform = canvasTransform()
+                        let worldSize = viewModel.worldSize(fallback: size)
+                        let fitScale = viewModel.fitScale(canvasSize: size)
+                        let transform = canvasTransform(worldSize: worldSize, fitScale: fitScale, canvasSize: size)
+
+                        // Apply transform to context so all drawing (image + strokes) moves together
+                        context.transform = transform
+
+                        // Draw background image if present (now transformed with strokes)
+                        if let bgImage = backgroundImage {
+                            let uiImage = UIImage(cgImage: bgImage.cgImage!)
+                            context.draw(
+                                Image(uiImage: uiImage),
+                                in: CGRect(x: 0, y: 0, width: worldSize.width, height: worldSize.height)
+                            )
+                        }
 
                         for stroke in viewModel.strokes {
-                            renderStroke(stroke, in: &context, transform: transform)
+                            renderStroke(stroke, in: &context)
                         }
 
                         if let current = currentStroke {
-                            renderStroke(current, in: &context, transform: transform)
+                            renderStroke(current, in: &context)
                         }
                     }
                     .coordinateSpace(.named("canvas"))
@@ -209,8 +223,8 @@ struct CanvasView: View {
                                     x: currentPoint.x - lastPointerPosition.x,
                                     y: currentPoint.y - lastPointerPosition.y
                                 )
-                                // Negate delta so dragging right pans right (not left)
-                                viewModel.pan(screenDelta: CGPoint(x: -delta.x, y: -delta.y))
+                                let fitScale = viewModel.fitScale(canvasSize: canvasSize)
+                                viewModel.pan(screenDelta: delta, fitScale: fitScale)
                             }
                             lastPointerPosition = currentPoint
                         } else {
@@ -332,26 +346,30 @@ struct CanvasView: View {
         }
     }
 
-    private func canvasTransform() -> CGAffineTransform {
-        let center = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
-        let liveScale = viewModel.zoomScale * gestureZoom
+    private func canvasTransform(worldSize: CGSize, fitScale: CGFloat, canvasSize: CGSize) -> CGAffineTransform {
+        let screenCenter = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
+        let imageCenterOffset = CGPoint(x: -worldSize.width / 2, y: -worldSize.height / 2)
+        let liveScale = viewModel.zoomScale * gestureZoom * fitScale
         let liveRotation = viewModel.rotationAngle + gestureRotation
 
         return CGAffineTransform.identity
-            .translatedBy(x: center.x, y: center.y)
+            .translatedBy(x: screenCenter.x, y: screenCenter.y)
             .rotated(by: liveRotation)
             .scaledBy(x: liveScale, y: liveScale)
-            .translatedBy(x: -center.x - viewModel.viewportOffset.x, y: -center.y - viewModel.viewportOffset.y)
+            .translatedBy(x: imageCenterOffset.x + viewModel.viewportOffset.x, y: imageCenterOffset.y + viewModel.viewportOffset.y)
     }
 
     private func screenToWorld(_ screenPoint: CGPoint) -> CGPoint {
         // Convert screen coordinate to world coordinate accounting for transform
-        let center = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
-        let scale = viewModel.zoomScale * gestureZoom
+        let worldSize = viewModel.worldSize(fallback: canvasSize)
+        let fitScale = viewModel.fitScale(canvasSize: canvasSize)
+        let screenCenter = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
+        let imageCenterOffset = CGPoint(x: -worldSize.width / 2, y: -worldSize.height / 2)
+        let scale = viewModel.zoomScale * gestureZoom * fitScale
         let rotation = viewModel.rotationAngle + gestureRotation
 
-        // Translate from center
-        var point = CGPoint(x: screenPoint.x - center.x, y: screenPoint.y - center.y)
+        // Translate from screen center
+        var point = CGPoint(x: screenPoint.x - screenCenter.x, y: screenPoint.y - screenCenter.y)
 
         // Inverse scale
         point.x /= scale
@@ -363,10 +381,11 @@ struct CanvasView: View {
         let rotatedX = point.x * cos - point.y * sin
         let rotatedY = point.x * sin + point.y * cos
 
-        // Add back center and viewport offset
+        // Add back image center offset and viewport offset (inverse of transform)
+        // The transform translates by (imageCenterOffset + viewportOffset), so we add those back
         return CGPoint(
-            x: rotatedX + center.x + viewModel.viewportOffset.x,
-            y: rotatedY + center.y + viewModel.viewportOffset.y
+            x: rotatedX - imageCenterOffset.x - viewModel.viewportOffset.x,
+            y: rotatedY - imageCenterOffset.y - viewModel.viewportOffset.y
         )
     }
 
@@ -386,6 +405,7 @@ struct CanvasView: View {
             do {
                 try await repository.removeBackgroundImage(for: canvasId)
                 viewModel.backgroundImageUrl = nil
+                viewModel.imageSize = nil
                 backgroundImage = nil
                 print("✅ Canvas and background image cleared")
             } catch {
@@ -394,7 +414,7 @@ struct CanvasView: View {
         }
     }
 
-    private func renderStroke(_ stroke: Stroke, in context: inout GraphicsContext, transform: CGAffineTransform) {
+    private func renderStroke(_ stroke: Stroke, in context: inout GraphicsContext) {
         guard stroke.points.count > 1 else { return }
 
         var path = Path()
@@ -405,12 +425,10 @@ struct CanvasView: View {
             path.addLine(to: CGPoint(x: point.x, y: point.y))
         }
 
-        // Apply transform to path
-        let transformedPath = path.applying(transform)
-
+        // context.transform is already applied, no need to transform path
         let color = Color(hex: stroke.color)
         context.stroke(
-            transformedPath,
+            path,
             with: .color(color),
             lineWidth: stroke.width
         )

--- a/SharedDrawing/Features/Canvas/CanvasViewModel.swift
+++ b/SharedDrawing/Features/Canvas/CanvasViewModel.swift
@@ -7,6 +7,7 @@ class CanvasViewModel {
     var currentColor: String = "#000000"  // Black by default
     var canvasId: String
     var backgroundImageUrl: String?
+    var imageSize: CGSize?  // Width/height of background image
     var viewportOffset: CGPoint = .zero  // Pan offset for larger virtual canvas
     var zoomScale: CGFloat = 1.0  // 0.5–5.0
     var rotationAngle: Double = 0.0  // Radians
@@ -32,15 +33,20 @@ class CanvasViewModel {
         canvasId = newCanvasId
         strokes = []
         backgroundImageUrl = nil
+        imageSize = nil
         resetTransform()
         setupStrokeListener()
     }
 
-    func pan(screenDelta: CGPoint) {
+    func pan(screenDelta: CGPoint, fitScale: CGFloat = 1.0) {
         // Convert screen-space delta to world-space delta accounting for rotation and scale
         var delta = screenDelta
 
-        // Undo scale
+        // Undo fit scale
+        delta.x /= fitScale
+        delta.y /= fitScale
+
+        // Undo zoom scale
         delta.x /= zoomScale
         delta.y /= zoomScale
 
@@ -68,6 +74,24 @@ class CanvasViewModel {
         rotationAngle = 0.0
     }
 
+    func worldSize(fallback: CGSize) -> CGSize {
+        return imageSize ?? fallback
+    }
+
+    func fitScale(canvasSize: CGSize) -> CGFloat {
+        guard let imageSize = imageSize else { return 1.0 }
+        let scaleX = canvasSize.width / imageSize.width
+        let scaleY = canvasSize.height / imageSize.height
+        return min(scaleX, scaleY)  // Fit to smallest dimension
+    }
+
+    func backfillImageDimensionsIfNeeded(width: Double, height: Double) async {
+        if imageSize == nil {
+            imageSize = CGSize(width: width, height: height)
+            try? await repository.updateBackgroundImageDimensions(width: width, height: height, for: canvasId)
+        }
+    }
+
     private func setupStrokeListener() {
         // Load background image from metadata and listen for real-time updates
         backgroundImageListenerTask = Task {
@@ -82,8 +106,16 @@ class CanvasViewModel {
                             print("📸 Background image cleared")
                         }
                     }
+
+                    // Poll for dimension updates
+                    if let dimensions = try await repository.getBackgroundImageDimensions(for: canvasId) {
+                        if imageSize != dimensions {
+                            imageSize = dimensions
+                            print("📐 Loaded image dimensions: \(dimensions)")
+                        }
+                    }
                 } catch {
-                    print("⚠️ Failed to load background image URL: \(error)")
+                    print("⚠️ Failed to load background image metadata: \(error)")
                 }
 
                 // Check for updates every 2 seconds
@@ -164,9 +196,12 @@ class CanvasViewModel {
         lastClearedStrokes = strokes
     }
 
-    func updateBackgroundImage(_ imageUrl: String) async throws {
-        try await repository.updateBackgroundImageUrl(imageUrl, for: canvasId)
+    func updateBackgroundImage(_ imageUrl: String, width: Double? = nil, height: Double? = nil) async throws {
+        try await repository.updateBackgroundImageUrl(imageUrl, width: width, height: height, for: canvasId)
         self.backgroundImageUrl = imageUrl
+        if let width = width, let height = height {
+            self.imageSize = CGSize(width: width, height: height)
+        }
         print("✅ Background image URL updated: \(imageUrl)")
     }
 


### PR DESCRIPTION
Fixes #95

## Overview
Implements Option C: Image-based coordinate system for perfect pixel-level alignment between background images and strokes.

## Key Features
- **Image-based coordinate system**: Image pixel space is canonical; strokes drawn in image pixels (1:1 alignment guaranteed)
- **Auto-fit zoom**: Images automatically scale to fit screen width on load (aspect-fit, uniform scaling)
- **Unified rendering**: Background image and strokes use same transform → move/zoom/rotate together perfectly
- **Real-time sync**: Image dimensions polled every 2 seconds for cross-device synchronization
- **Lazy backfill**: Legacy canvases auto-backfill image dimensions on first download (backward compatible)

## Bug Fixes
- ✅ Pan direction inverted (removed incorrect delta negation)
- ✅ Stroke tap location offset (fixed screenToWorld transform inversion math)
- ✅ Background image positioned incorrectly (now draws from 0,0 in image space)
- ✅ Image and strokes misaligned during pan/zoom/rotate (now use unified context.transform)

## Files Changed
- `CanvasMeta.swift`: Added optional imageWidth/imageHeight fields
- `CanvasRepository.swift`: Updated signatures for atomic image metadata writes
- `FirebaseCanvasRepository.swift`: Implemented atomic writes, dimension polling
- `CanvasViewModel.swift`: Added imageSize, worldSize/fitScale helpers, polling listener
- `CanvasView.swift`: Unified canvas transform, fixed coordinate conversions

## Technical Details

### Coordinate System
- **World space**: Image pixel coordinates (0,0 to imageWidth, imageHeight)
- **Screen space**: Device screen coordinates (0,0 to canvasWidth, canvasHeight)
- **Transform**: Maps world to screen via center-anchored rotate/scale + pan
- **Auto-fit**: fitScale = min(screenWidth/imageWidth, screenHeight/imageHeight)

### Rendering
- Canvas context.transform applied once, affects all drawing (image + strokes)
- Image drawn from (0,0) to (imageWidth, imageHeight) in world space
- Strokes stored/synced in world coordinates (never in screen coordinates)

### Touch Input
- screenToWorld converts tap location via inverse transform
- Uses same worldSize and fitScale as rendering for consistency
- Fixed: now correctly negates viewport offset in inverse math

## Acceptance Criteria
- ✅ Image and strokes perfectly aligned at 1:1 pixel level
- ✅ Overlay annotations appear exactly where drawn
- ✅ Pan/zoom/rotate moves image and strokes together
- ✅ Consistent across devices and orientations
- ✅ Real-time sync across connected devices
- ✅ Backward compatible with legacy canvases (auto-backfill)

## Testing
- ✅ Image loads and auto-fits to screen width
- ✅ Strokes draw at exact tap location
- ✅ Pan/zoom/rotate move image and strokes together
- ✅ Different devices auto-fit differently but alignment maintained
- ✅ Legacy canvases auto-backfill dimensions on image load