### PR TITLE
Phase 3: Google OAuth login for image uploads

### DIFF
--- a/GoogleService-Info.plist
+++ b/GoogleService-Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CLIENT_ID</key>
+	<string>1006489746800-lu0ferggbcbp8qssl3v51k6s99jmo8k1.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.1006489746800-lu0ferggbcbp8qssl3v51k6s99jmo8k1</string>
 	<key>API_KEY</key>
 	<string>AIzaSyByhm98OlMUif0jJ-dL1l9LwwDWMfBihTw</string>
 	<key>GCM_SENDER_ID</key>

--- a/Info.plist
+++ b/Info.plist
@@ -14,6 +14,14 @@
 				<string>shareddrawing</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.1006489746800-lu0ferggbcbp8qssl3v51k6s99jmo8k1</string>
+			</array>
+		</dict>
 	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>

--- a/SharedDrawing.xcodeproj/project.pbxproj
+++ b/SharedDrawing.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		729f6c869387cb051b38b8ac /* SharedDrawing/CanvasMeta.swift in Resources */ = {isa = PBXBuildFile; fileRef = efeeb40bbcfbf05e508df18f /* SharedDrawing/CanvasMeta.swift */; };
 		FB02000000000000000000001 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = FB02000000000000000000002 /* FirebaseAuth */; };
 		FB03000000000000000000001 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = FB03000000000000000000002 /* FirebaseDatabase */; };
+		FB04000000000000000000001 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = FB04000000000000000000002 /* GoogleSignIn */; };
 		abb2691eb9341c1d2e3579ed /* SharedDrawing/StrokeCaptureView.swift in Resources */ = {isa = PBXBuildFile; fileRef = 886d36225c7d82f3226d85ed /* SharedDrawing/StrokeCaptureView.swift */; };
 		c6a8fe5d33e8aaf6bd10b62a /* SharedDrawing/CanvasViewModel.swift in Resources */ = {isa = PBXBuildFile; fileRef = cf10c97bb6a4fd438ac6d29c /* SharedDrawing/CanvasViewModel.swift */; };
 		f4737b48d7a3b5238aea19b3 /* SharedDrawing/CanvasRepository.swift in Resources */ = {isa = PBXBuildFile; fileRef = 4238650f4565289756e3e00c /* SharedDrawing/CanvasRepository.swift */; };
@@ -62,6 +63,7 @@
 				45DDFB553019AF4900D2CFEF /* JWTKit in Frameworks */,
 				FB02000000000000000000001 /* FirebaseAuth in Frameworks */,
 				FB03000000000000000000001 /* FirebaseDatabase in Frameworks */,
+				FB04000000000000000000001 /* GoogleSignIn in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -184,6 +186,7 @@
 				FB01000000000000000000001 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				451C7D8A301593DA001B6350 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				45DDFB533019AF4900D2CFEF /* XCRemoteSwiftPackageReference "jwt-kit" */,
+				FB05000000000000000000001 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -461,6 +464,14 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 		};
+		FB05000000000000000000001 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -478,6 +489,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = FB01000000000000000000001 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseDatabase;
+		};
+		FB04000000000000000000002 /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FB05000000000000000000001 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/SharedDrawing.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SharedDrawing.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c9413117e58952354105a6297204edc4311248d2b425bc308c52f8d4f55f40d9",
+  "originHash" : "e61e41469a54319ef0635a68f7394a5097f4b3a695eaa4c7d058b799e242c25a",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
         "version" : "11.3.1"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "2781038865a80e2c425a1da12cc1327bcd56501f",
+        "version" : "1.7.6"
       }
     },
     {
@@ -56,6 +65,15 @@
       }
     },
     {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "a7965d134c5d3567026c523e0a8a583f73b62b0d",
+        "version" : "7.1.0"
+      }
+    },
+    {
       "identity" : "googleutilities",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
@@ -78,8 +96,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "c0ac7575d70050c2973ba2318bd5af47f8e8153a",
-        "version" : "5.3.0"
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
       }
     },
     {

--- a/SharedDrawing/AuthService.swift
+++ b/SharedDrawing/AuthService.swift
@@ -1,10 +1,36 @@
 import Foundation
 import FirebaseAuth
+import FirebaseCore
+import GoogleSignIn
+import UIKit
 import Observation
+
+enum AuthError: LocalizedError {
+    case missingClientID
+    case noPresentingViewController
+    case missingIDToken
+    case cancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .missingClientID:
+            return "Google Sign-In client ID not found in Firebase configuration"
+        case .noPresentingViewController:
+            return "Unable to present sign-in sheet"
+        case .missingIDToken:
+            return "Failed to retrieve ID token from Google Sign-In"
+        case .cancelled:
+            return "Sign-in was cancelled by the user"
+        }
+    }
+}
 
 @Observable
 class AuthService {
     var currentUserID: String?
+    var currentUserName: String?
+    var currentUserEmail: String?
+    var isAnonymous = true
     var isAuthenticated: Bool { currentUserID != nil }
 
     private var authStateListener: AuthStateDidChangeListenerHandle?
@@ -22,11 +48,106 @@ class AuthService {
     private func setupAuthStateListener() {
         authStateListener = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             self?.currentUserID = user?.uid
+            if let user = user {
+                self?.currentUserName = user.displayName
+                self?.currentUserEmail = user.email
+                // Check if user is anonymous
+                self?.isAnonymous = user.isAnonymous
+            } else {
+                self?.currentUserName = nil
+                self?.currentUserEmail = nil
+                self?.isAnonymous = true
+            }
         }
     }
 
     func signInAnonymously() async throws {
         let result = try await Auth.auth().signInAnonymously()
         currentUserID = result.user.uid
+        isAnonymous = true
+    }
+
+    func signInWithGoogle() async throws {
+        guard let clientID = FirebaseApp.app()?.options.clientID else {
+            throw AuthError.missingClientID
+        }
+
+        // Configure Google Sign-In
+        let config = GIDConfiguration(clientID: clientID)
+        GIDSignIn.sharedInstance.configuration = config
+
+        guard let topVC = Self.topViewController() else {
+            throw AuthError.noPresentingViewController
+        }
+
+        let result: GIDSignInResult
+        do {
+            result = try await GIDSignIn.sharedInstance.signIn(withPresenting: topVC)
+        } catch let error as NSError where error.code == GIDSignInError.Code.canceled.rawValue {
+            throw AuthError.cancelled
+        }
+
+        guard let idToken = result.user.idToken?.tokenString else {
+            throw AuthError.missingIDToken
+        }
+
+        let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: result.user.accessToken.tokenString)
+
+        // Try to link to current anonymous user
+        if let anonUser = Auth.auth().currentUser, anonUser.isAnonymous {
+            do {
+                _ = try await anonUser.link(with: credential)
+                currentUserID = anonUser.uid
+                currentUserName = result.user.profile?.givenName
+                currentUserEmail = result.user.profile?.email
+                isAnonymous = false
+            } catch let error as NSError where error.code == AuthErrorCode.credentialAlreadyInUse.rawValue {
+                // Credential already linked elsewhere, sign in normally
+                _ = try await Auth.auth().signIn(with: credential)
+                if let firebaseUser = Auth.auth().currentUser {
+                    currentUserID = firebaseUser.uid
+                    currentUserName = firebaseUser.displayName
+                    currentUserEmail = firebaseUser.email
+                    isAnonymous = false
+                }
+            }
+        } else {
+            // No anonymous user or already authenticated, sign in normally
+            _ = try await Auth.auth().signIn(with: credential)
+            if let firebaseUser = Auth.auth().currentUser {
+                currentUserID = firebaseUser.uid
+                currentUserName = firebaseUser.displayName
+                currentUserEmail = firebaseUser.email
+                isAnonymous = false
+            }
+        }
+    }
+
+    func signOut() async throws {
+        GIDSignIn.sharedInstance.signOut()
+        try Auth.auth().signOut()
+        try await signInAnonymously()
+    }
+
+    static func topViewController() -> UIViewController? {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            return nil
+        }
+
+        var topViewController = windowScene.windows.first?.rootViewController
+
+        while let presentedViewController = topViewController?.presentedViewController {
+            topViewController = presentedViewController
+        }
+
+        if let navigationController = topViewController as? UINavigationController {
+            topViewController = navigationController.visibleViewController
+        }
+
+        if let tabBarController = topViewController as? UITabBarController {
+            topViewController = tabBarController.selectedViewController
+        }
+
+        return topViewController
     }
 }

--- a/SharedDrawing/Core/Networking/CanvasRepository.swift
+++ b/SharedDrawing/Core/Networking/CanvasRepository.swift
@@ -11,7 +11,15 @@ protocol CanvasRepository {
     func addStroke(_ stroke: Stroke, to canvasId: String) async throws
     func updateStroke(_ stroke: Stroke, in canvasId: String) async throws
     func removeStroke(id: String, from canvasId: String) async throws
-    func updateBackgroundImageUrl(_ url: String, width: Double?, height: Double?, for canvasId: String) async throws
+    func updateBackgroundImageUrl(
+        _ url: String,
+        width: Double?,
+        height: Double?,
+        uploaderId: String?,
+        uploaderName: String?,
+        uploaderEmail: String?,
+        for canvasId: String
+    ) async throws
     func getBackgroundImageUrl(for canvasId: String) async throws -> String?
     func getBackgroundImageDimensions(for canvasId: String) async throws -> CGSize?
     func updateBackgroundImageDimensions(width: Double, height: Double, for canvasId: String) async throws

--- a/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
+++ b/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
@@ -63,7 +63,15 @@ class FirebaseCanvasRepository: CanvasRepository {
         try await strokeRef.removeValue()
     }
 
-    func updateBackgroundImageUrl(_ url: String, width: Double?, height: Double?, for canvasId: String) async throws {
+    func updateBackgroundImageUrl(
+        _ url: String,
+        width: Double?,
+        height: Double?,
+        uploaderId: String?,
+        uploaderName: String?,
+        uploaderEmail: String?,
+        for canvasId: String
+    ) async throws {
         let metaRef = database.child("v2/canvases").child(canvasId).child("meta")
         var updates: [String: Any] = ["backgroundImageUrl": url]
         if let width = width {
@@ -71,6 +79,12 @@ class FirebaseCanvasRepository: CanvasRepository {
         }
         if let height = height {
             updates["imageHeight"] = height
+        }
+        if let uploaderId = uploaderId {
+            updates["uploadedBy"] = uploaderId
+            updates["uploaderName"] = uploaderName as Any
+            updates["uploaderEmail"] = uploaderEmail as Any
+            updates["uploadedAt"] = ServerValue.timestamp()
         }
         try await metaRef.updateChildValues(updates)
     }
@@ -99,8 +113,16 @@ class FirebaseCanvasRepository: CanvasRepository {
 
     func removeBackgroundImage(for canvasId: String) async throws {
         let metaRef = database.child("v2/canvases").child(canvasId).child("meta")
-        try await metaRef.updateChildValues(["backgroundImageUrl": NSNull(), "imageWidth": NSNull(), "imageHeight": NSNull()])
-        print("🗑️ Dropped backgroundImageUrl, imageWidth, and imageHeight nodes for canvas \(canvasId)")
+        try await metaRef.updateChildValues([
+            "backgroundImageUrl": NSNull(),
+            "imageWidth": NSNull(),
+            "imageHeight": NSNull(),
+            "uploadedBy": NSNull(),
+            "uploaderName": NSNull(),
+            "uploaderEmail": NSNull(),
+            "uploadedAt": NSNull()
+        ])
+        print("🗑️ Dropped backgroundImageUrl, imageWidth, imageHeight, and uploader fields for canvas \(canvasId)")
     }
 
     // MARK: - Private Helpers

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -16,6 +16,9 @@ struct CanvasView: View {
     @GestureState private var gestureZoom: CGFloat = 1.0
     @GestureState private var gestureRotation: Double = 0.0
     @State private var canvasSize: CGSize = .zero
+    @State private var showSignInPrompt = false
+    @State private var signInErrorMessage: String? = nil
+    @State private var showSignInError = false
 
     @Binding var canvasId: String
     let repository: CanvasRepository
@@ -60,6 +63,14 @@ struct CanvasView: View {
                     Image(systemName: isPointerMode ? "hand.point.up.fill" : "pencil")
                         .font(.system(size: 14))
                         .foregroundColor(isPointerMode ? .blue : .primary)
+                }
+
+                if !viewModel.isAnonymous {
+                    Button(action: { Task { try? await authService.signOut() } }) {
+                        Image(systemName: "person.crop.circle.badge.minus")
+                            .font(.system(size: 14))
+                    }
+                    .accessibilityLabel("Sign out")
                 }
 
                 Button(action: {
@@ -297,7 +308,7 @@ struct CanvasView: View {
                         ColorPalettePicker(
                             selectedColor: $viewModel.currentColor,
                             vertical: true,
-                            onImagePickerTapped: { showImagePicker = true }
+                            onImagePickerTapped: { handleAddImageTapped() }
                         )
                     } else {
                         Circle()
@@ -343,6 +354,17 @@ struct CanvasView: View {
             currentStroke = nil
             isDrawing = false
             viewModel.switchToCanvas(newCanvasId)
+        }
+        .alert("Sign in required", isPresented: $showSignInPrompt) {
+            Button("Sign in with Google") { Task { await performGoogleSignIn() } }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Sign in with Google to add a background image.")
+        }
+        .alert("Sign-In Failed", isPresented: $showSignInError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(signInErrorMessage ?? "Something went wrong.")
         }
     }
 
@@ -432,6 +454,26 @@ struct CanvasView: View {
             with: .color(color),
             lineWidth: stroke.width
         )
+    }
+
+    private func handleAddImageTapped() {
+        if viewModel.isAnonymous {
+            showSignInPrompt = true
+        } else {
+            showImagePicker = true
+        }
+    }
+
+    private func performGoogleSignIn() async {
+        do {
+            try await authService.signInWithGoogle()
+            showImagePicker = true
+        } catch AuthError.cancelled {
+            // Silent — user backed out of Google sheet
+        } catch {
+            signInErrorMessage = error.localizedDescription
+            showSignInError = true
+        }
     }
 }
 

--- a/SharedDrawing/Features/Canvas/CanvasViewModel.swift
+++ b/SharedDrawing/Features/Canvas/CanvasViewModel.swift
@@ -12,6 +12,7 @@ class CanvasViewModel {
     var zoomScale: CGFloat = 1.0  // 0.5–5.0
     var rotationAngle: Double = 0.0  // Radians
     var canUndo: Bool { !undoStack.isEmpty || lastClearedStrokes != nil }
+    var isAnonymous: Bool { authService.isAnonymous }
 
     let repository: CanvasRepository
     private let authService: AuthService
@@ -197,7 +198,19 @@ class CanvasViewModel {
     }
 
     func updateBackgroundImage(_ imageUrl: String, width: Double? = nil, height: Double? = nil) async throws {
-        try await repository.updateBackgroundImageUrl(imageUrl, width: width, height: height, for: canvasId)
+        let uploaderId = isAnonymous ? nil : authService.currentUserID
+        let uploaderName = isAnonymous ? nil : authService.currentUserName
+        let uploaderEmail = isAnonymous ? nil : authService.currentUserEmail
+
+        try await repository.updateBackgroundImageUrl(
+            imageUrl,
+            width: width,
+            height: height,
+            uploaderId: uploaderId,
+            uploaderName: uploaderName,
+            uploaderEmail: uploaderEmail,
+            for: canvasId
+        )
         self.backgroundImageUrl = imageUrl
         if let width = width, let height = height {
             self.imageSize = CGSize(width: width, height: height)

--- a/SharedDrawing/SharedDrawingApp.swift
+++ b/SharedDrawing/SharedDrawingApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Firebase
+import GoogleSignIn
 
 @main
 struct SharedDrawingApp: App {
@@ -28,6 +29,9 @@ struct SharedDrawingApp: App {
             }
             .onOpenURL { url in
                 print("🔗 Received URL:", url.absoluteString)
+                if GIDSignIn.sharedInstance.handle(url) {
+                    return
+                }
                 if let canvasId = url.queryItemValue(for: "id") {
                     print("🎯 Parsed Canvas ID:", canvasId)
                     deepLinkCanvasId = canvasId


### PR DESCRIPTION
## Summary
Implement lazy Google Sign-In on top of existing anonymous auth, gated behind "Add Background Image" action. Users start anonymous and can draw immediately—Google login is only required when uploading background images.

## Key Changes
- **AuthService**: Google Sign-In setup, session persistence, logout
- **CanvasView**: Login prompt (appears only when adding images), logout button
- **CanvasViewModel**: Auth state passthrough for UI gating
- **Firebase repositories**: Uploader attribution metadata (name, email, timestamp)
- **SharedDrawingApp**: OAuth redirect handler
- **Dependencies**: Added GoogleSignIn-iOS SPM package

## User Flow
1. App opens → anonymous session, can draw immediately
2. User draws/collaborates → no login needed
3. User taps "Add Background Image":
   - If anonymous → show "Sign in with Google" prompt
   - If already logged in → proceed to image picker
4. After login → auth persists locally across app restarts
5. Logout returns to anonymous mode

## Test Plan
- [ ] Fresh launch → drawing works anonymously (no login prompt)
- [ ] Tap "Add Background Image" while anonymous → sign-in alert appears
- [ ] Tap "Sign in with Google" → complete OAuth flow → image picker opens
- [ ] Verify uploader metadata in Firebase console after upload
- [ ] Force-quit and relaunch → still signed in (Keychain persistence)
- [ ] Tap logout → back to anonymous mode, drawing still works
- [ ] Cancel Google's account picker → no error alert, stays anonymous
- [ ] Draw strokes before and after login → verify same userId on link

## Fixes #76