### PR TITLE
Phase 3: Pen style selection with collapsible palette UI

### DIFF
--- a/SharedDrawing/Core/Models/PenStyle.swift
+++ b/SharedDrawing/Core/Models/PenStyle.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum PenStyle: String, Codable, CaseIterable, Identifiable, Hashable {
+    case ballpoint, marker, highlighter, calligraphy, pencil
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .ballpoint: return "Ballpoint"
+        case .marker: return "Marker"
+        case .highlighter: return "Highlighter"
+        case .calligraphy: return "Calligraphy"
+        case .pencil: return "Pencil"
+        }
+    }
+
+    var minWidth: Double {
+        switch self {
+        case .ballpoint: return 2.0
+        case .marker: return 4.0
+        case .highlighter: return 8.0
+        case .calligraphy: return 2.0
+        case .pencil: return 2.5
+        }
+    }
+
+    var maxWidth: Double {
+        switch self {
+        case .ballpoint: return 2.0
+        case .marker: return 4.0
+        case .highlighter: return 8.0
+        case .calligraphy: return 5.0
+        case .pencil: return 2.5
+        }
+    }
+
+    var baseWidth: Double { minWidth }
+
+    var opacity: Double {
+        switch self {
+        case .ballpoint: return 1.0
+        case .marker: return 0.6
+        case .highlighter: return 0.3
+        case .calligraphy: return 0.85
+        case .pencil: return 0.8
+        }
+    }
+
+    var usesScreenBlend: Bool {
+        switch self {
+        case .marker, .highlighter: return true
+        default: return false
+        }
+    }
+
+    static let `default`: PenStyle = .ballpoint
+}

--- a/SharedDrawing/Core/Models/Stroke.swift
+++ b/SharedDrawing/Core/Models/Stroke.swift
@@ -8,4 +8,5 @@ struct Stroke: Identifiable, Codable {
     var points: [StrokePoint]
     var isComplete: Bool
     let createdAt: TimeInterval
+    let style: String
 }

--- a/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
+++ b/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
@@ -1,5 +1,8 @@
 import Foundation
 import FirebaseDatabase
+import os.log
+
+private let logger = Logger(subsystem: "io.github.nicechester.shareddrawing", category: "Firebase")
 
 class FirebaseCanvasRepository: CanvasRepository {
     private let database: DatabaseReference
@@ -42,9 +45,9 @@ class FirebaseCanvasRepository: CanvasRepository {
     func addStroke(_ stroke: Stroke, to canvasId: String) async throws {
         let strokeRef = database.child("v2/canvases").child(canvasId).child("strokes").child(stroke.id)
         let strokeData = try encodedStrokeData(stroke)
-        print("📤 Adding stroke \(stroke.id) to canvas \(canvasId): \(strokeData.count) fields")
+        logger.debug("Adding stroke \(stroke.id) to canvas \(canvasId): \(strokeData.count) fields")
         try await strokeRef.setValue(strokeData)
-        print("✅ Stroke \(stroke.id) added successfully")
+        logger.debug("Stroke \(stroke.id) added successfully")
 
         // Update canvas lastActivityAt for retention policy
         let metaRef = database.child("v2/canvases").child(canvasId).child("meta").child("lastActivityAt")
@@ -54,7 +57,7 @@ class FirebaseCanvasRepository: CanvasRepository {
     func updateStroke(_ stroke: Stroke, in canvasId: String) async throws {
         let strokeRef = database.child("v2/canvases").child(canvasId).child("strokes").child(stroke.id)
         let strokeData = try encodedStrokeData(stroke)
-        print("📤 Updating stroke \(stroke.id) in canvas \(canvasId): \(stroke.points.count) points")
+        logger.debug("Updating stroke \(stroke.id) in canvas \(canvasId): \(stroke.points.count) points")
         try await strokeRef.updateChildValues(strokeData)
     }
 
@@ -122,7 +125,7 @@ class FirebaseCanvasRepository: CanvasRepository {
             "uploaderEmail": NSNull(),
             "uploadedAt": NSNull()
         ])
-        print("🗑️ Dropped backgroundImageUrl, imageWidth, imageHeight, and uploader fields for canvas \(canvasId)")
+        logger.debug("Dropped backgroundImageUrl, imageWidth, imageHeight, and uploader fields for canvas \(canvasId)")
     }
 
     // MARK: - Private Helpers

--- a/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
+++ b/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
@@ -151,6 +151,7 @@ class FirebaseCanvasRepository: CanvasRepository {
             }
         }
 
+        let style = dict["style"] as? String ?? PenStyle.default.rawValue
         return Stroke(
             id: id,
             userId: userId,
@@ -158,7 +159,8 @@ class FirebaseCanvasRepository: CanvasRepository {
             width: width,
             points: points,
             isComplete: isComplete,
-            createdAt: createdAt
+            createdAt: createdAt,
+            style: style
         )
     }
 
@@ -173,7 +175,8 @@ class FirebaseCanvasRepository: CanvasRepository {
             "width": stroke.width,
             "points": pointsData,
             "isComplete": stroke.isComplete,
-            "createdAt": stroke.createdAt
+            "createdAt": stroke.createdAt,
+            "style": stroke.style
         ]
     }
 }

--- a/SharedDrawing/Core/Networking/GCSImageUploader.swift
+++ b/SharedDrawing/Core/Networking/GCSImageUploader.swift
@@ -1,5 +1,8 @@
 import Foundation
 import JWTKit
+import os.log
+
+private let logger = Logger(subsystem: "io.github.nicechester.shareddrawing", category: "GCS")
 
 struct GCSClaims: JWTPayload {
     var iss: IssuerClaim
@@ -30,7 +33,7 @@ class GCSImageUploader {
     func uploadImage(_ imageData: Data, canvasId: String, userId: String) async throws -> String {
         let fileName = "\(UUID().uuidString).jpg"
         let objectPath = "canvases/\(canvasId)/\(userId)/\(fileName)"
-        print("📤 Uploading image to GCS: \(objectPath)")
+        logger.debug("Uploading image to GCS: \(objectPath)")
 
         let accessToken = try await getAccessToken()
 
@@ -50,11 +53,11 @@ class GCSImageUploader {
         
         guard http.statusCode == 200 else {
             let errorBody = String(data: imageData.prefix(500), encoding: .utf8) ?? ""
-            print("❌ Upload failed: \(http.statusCode) \(errorBody)")
+            logger.error("Upload failed: \(http.statusCode) \(errorBody)")
             throw NSError(domain: "GCS", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "Upload failed: \(http.statusCode)"])
         }
 
-        print("✅ Image uploaded: \(objectPath)")
+        logger.info("Image uploaded: \(objectPath)")
         return "https://storage.googleapis.com/\(bucket)/\(objectPath)"
     }
 
@@ -75,7 +78,7 @@ class GCSImageUploader {
         )
 
         let jwt = try await keys.sign(payload)
-        print("📝 JWT created, exchanging for access token...")
+        logger.debug("JWT created, exchanging for access token...")
 
         var req = URLRequest(url: URL(string: "https://oauth2.googleapis.com/token")!)
         req.httpMethod = "POST"
@@ -83,19 +86,19 @@ class GCSImageUploader {
         req.httpBody = "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=\(jwt)".data(using: .utf8)
 
         let (data, response) = try await URLSession.shared.data(for: req)
-        
+
         if let http = response as? HTTPURLResponse {
-            print("📊 Token response: \(http.statusCode)")
+            logger.debug("Token response: \(http.statusCode)")
         }
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
 
         guard let token = json?["access_token"] as? String else {
             let err = json?["error_description"] as? String ?? json?["error"] as? String ?? "Unknown"
-            print("❌ GCS error: \(err)")
+            logger.error("GCS error: \(err)")
             throw NSError(domain: "GCS", code: -1, userInfo: [NSLocalizedDescriptionKey: "Token error: \(err)"])
         }
-        print("✅ Access token obtained")
+        logger.info("Access token obtained")
         return token
     }
 }

--- a/SharedDrawing/Core/Networking/ServiceAccountLoader.swift
+++ b/SharedDrawing/Core/Networking/ServiceAccountLoader.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "io.github.nicechester.shareddrawing", category: "ServiceAccount")
 
 struct ServiceAccountKey: Codable {
     let type: String
@@ -16,19 +19,19 @@ struct ServiceAccountKey: Codable {
 class ServiceAccountLoader {
     static func loadKey(from filename: String = "shared-drawing-7910b9b25a2d.json") -> ServiceAccountKey? {
         guard let path = Bundle.main.path(forResource: filename.replacingOccurrences(of: ".json", with: ""), ofType: "json") else {
-            print("⚠️ Service account key file not found: \(filename)")
+            logger.warning("Service account key file not found: \(filename)")
             return nil
         }
 
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-            print("⚠️ Failed to read service account key file")
+            logger.warning("Failed to read service account key file")
             return nil
         }
 
         do {
             return try JSONDecoder().decode(ServiceAccountKey.self, from: data)
         } catch {
-            print("⚠️ Failed to decode service account key: \(error)")
+            logger.warning("Failed to decode service account key: \(error)")
             return nil
         }
     }

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+import os.log
+
+private let logger = Logger(subsystem: "io.github.nicechester.shareddrawing", category: "CanvasView")
 import Observation
 
 struct CanvasView: View {
@@ -107,13 +110,13 @@ struct CanvasView: View {
                 Task {
                     do {
                         guard let jpegData = newImage.jpegData(compressionQuality: 0.8) else {
-                            print("❌ Failed to compress image")
+                            logger.error("Failed to compress image")
                             return
                         }
 
                         // Upload to GCS and get signed URL
                         guard let serviceAccount = ServiceAccountLoader.loadKey() else {
-                            print("❌ Service account key not found")
+                            logger.error("Service account key not found")
                             return
                         }
 
@@ -128,9 +131,9 @@ struct CanvasView: View {
                         let width = Double(newImage.size.width)
                         let height = Double(newImage.size.height)
                         try await viewModel.updateBackgroundImage(signedURL, width: width, height: height)
-                        print("✅ Background image uploaded and stored: \(signedURL)")
+                        logger.info("Background image uploaded and stored: \(signedURL)")
                     } catch {
-                        print("❌ Error uploading image: \(error)")
+                        logger.error("Error uploading image: \(error)")
                     }
                 }
             }
@@ -142,7 +145,7 @@ struct CanvasView: View {
                             if let uiImage = UIImage(data: data) {
                                 DispatchQueue.main.async {
                                     self.backgroundImage = uiImage
-                                    print("✅ Background image loaded from URL")
+                                    logger.info("Background image loaded from URL")
                                 }
                                 // Backfill dimensions if not already set
                                 let width = Double(uiImage.size.width)
@@ -150,13 +153,13 @@ struct CanvasView: View {
                                 await viewModel.backfillImageDimensionsIfNeeded(width: width, height: height)
                             }
                         } catch {
-                            print("❌ Failed to load background image from URL: \(error)")
+                            logger.error("Failed to load background image from URL: \(error)")
                         }
                     }
                 } else {
                     // URL was cleared, remove background image
                     backgroundImage = nil
-                    print("✅ Background image cleared")
+                    logger.info("Background image cleared")
                 }
             }
 
@@ -216,13 +219,13 @@ struct CanvasView: View {
                             lastPointerPosition = currentPoint
                         } else {
                             // In pen mode, draw strokes
-                            print("📍 Touch: \(points.count) points, isDrawing=\(isDrawing)")
+                            logger.debug("Touch: \(points.count) points, isDrawing=\(isDrawing)")
 
                             // Convert screen coordinates to world coordinates
                             let adjustedPoints = points.map { screenToWorld($0) }
 
                             if !isDrawing {
-                                print("🎨 Starting new stroke")
+                                logger.debug("Starting new stroke")
                                 isDrawing = true
                                 currentStroke = viewModel.startStroke(at: adjustedPoints.first ?? .zero)
                             }
@@ -240,7 +243,7 @@ struct CanvasView: View {
                                         do {
                                             try await viewModel.repository.updateStroke(stroke, in: canvasId)
                                         } catch {
-                                            print("❌ Error updating stroke: \(error)")
+                                            logger.error("Error updating stroke: \(error)")
                                         }
                                     }
                                 }
@@ -252,10 +255,10 @@ struct CanvasView: View {
                             // Reset pointer tracking
                             lastPointerPosition = .zero
                         } else {
-                            print("✋ Stroke ended, submitting \(currentStroke?.points.count ?? 0) points")
+                            logger.debug("Stroke ended, submitting \(currentStroke?.points.count ?? 0) points")
                             guard let stroke = currentStroke else { return }
                             guard stroke.points.count >= 2 else {
-                                print("⚠️ Ignoring single-point stroke")
+                                logger.warning("Ignoring single-point stroke")
                                 currentStroke = nil
                                 isDrawing = false
                                 return
@@ -265,7 +268,7 @@ struct CanvasView: View {
                             isDrawing = false
                             Task {
                                 await viewModel.submitStroke(endedStroke)
-                                print("✅ Stroke submitted")
+                                logger.info("Stroke submitted")
                             }
                         }
                     }
@@ -374,7 +377,7 @@ struct CanvasView: View {
                 do {
                     try await repository.removeStroke(id: stroke.id, from: canvasId)
                 } catch {
-                    print("❌ Error clearing stroke: \(error)")
+                    logger.error("Error clearing stroke: \(error)")
                 }
             }
             viewModel.strokes = []
@@ -385,9 +388,9 @@ struct CanvasView: View {
                 viewModel.backgroundImageUrl = nil
                 viewModel.imageSize = nil
                 backgroundImage = nil
-                print("✅ Canvas and background image cleared")
+                logger.info("Canvas and background image cleared")
             } catch {
-                print("❌ Error clearing background image: \(error)")
+                logger.error("Error clearing background image: \(error)")
             }
         }
     }

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Observation
 
 struct CanvasView: View {
     @State private var viewModel: CanvasViewModel
@@ -6,8 +7,6 @@ struct CanvasView: View {
     @State private var isDrawing = false
     @State private var lastUpdateTime: Date?
     @State private var showCanvasIDSheet = false
-    @State private var showClearConfirmation = false
-    @State private var isPaletteCollapsed = false
     @State private var showImagePicker = false
     @State private var selectedImage: UIImage?
     @State private var backgroundImage: UIImage?
@@ -58,13 +57,6 @@ struct CanvasView: View {
                     }
                 }
 
-                // Pointer/Pen toggle
-                Button(action: { isPointerMode.toggle() }) {
-                    Image(systemName: isPointerMode ? "hand.point.up.fill" : "pencil")
-                        .font(.system(size: 14))
-                        .foregroundColor(isPointerMode ? .blue : .primary)
-                }
-
                 if !viewModel.isAnonymous {
                     Button(action: { Task { try? await authService.signOut() } }) {
                         Image(systemName: "person.crop.circle.badge.minus")
@@ -93,14 +85,6 @@ struct CanvasView: View {
                     Image(systemName: "square.and.arrow.up")
                         .font(.system(size: 14))
                 }
-
-                Button(action: {
-                    showClearConfirmation = true
-                }) {
-                    Image(systemName: "trash")
-                        .font(.system(size: 14))
-                        .foregroundColor(.red)
-                }
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
@@ -113,14 +97,6 @@ struct CanvasView: View {
                     canvasId: $canvasId,
                     isPresented: $showCanvasIDSheet
                 )
-            }
-            .alert("Clear All Strokes?", isPresented: $showClearConfirmation) {
-                Button("Cancel", role: .cancel) { }
-                Button("Clear", role: .destructive) {
-                    clearAllStrokes()
-                }
-            } message: {
-                Text("This will permanently delete all drawings on this canvas. This action cannot be undone.")
             }
             .sheet(isPresented: $showImagePicker) {
                 ImagePicker(isPresented: $showImagePicker, selectedImage: $selectedImage)
@@ -295,35 +271,15 @@ struct CanvasView: View {
                     }
                 )
 
-                // Floating color palette (top-left)
-                VStack(spacing: 12) {
-                    Button(action: { isPaletteCollapsed.toggle() }) {
-                        Text(isPaletteCollapsed ? "v" : "^")
-                            .font(.system(size: 14, weight: .bold))
-                            .foregroundColor(.gray)
-                            .frame(width: 24, height: 24)
-                    }
-
-                    if !isPaletteCollapsed {
-                        ColorPalettePicker(
-                            selectedColor: $viewModel.currentColor,
-                            vertical: true,
-                            onImagePickerTapped: { handleAddImageTapped() }
-                        )
-                    } else {
-                        Circle()
-                            .fill(Color(hex: viewModel.currentColor))
-                            .frame(width: 32, height: 32)
-                            .overlay(
-                                Circle()
-                                    .stroke(Color.white, lineWidth: 2)
-                            )
-                    }
-                }
+                ColorPalettePicker(
+                    selectedColor: $viewModel.currentColor,
+                    selectedPenStyle: $viewModel.selectedPenStyle,
+                    isPointerMode: $isPointerMode,
+                    onImagePickerTapped: { handleAddImageTapped() },
+                    onClearTapped: { clearAllStrokes() }
+                )
                 .padding(.horizontal, 8)
                 .padding(.vertical, 12)
-                .background(Color(.systemGray6))
-                .cornerRadius(8)
             }
             .gesture(
                 SimultaneousGesture(
@@ -438,22 +394,37 @@ struct CanvasView: View {
 
     private func renderStroke(_ stroke: Stroke, in context: inout GraphicsContext) {
         guard stroke.points.count > 1 else { return }
+        let style = PenStyle(rawValue: stroke.style) ?? .default
+        let color = Color(hex: stroke.color)
+        context.applyPenStyle(style)
+
+        if style == .calligraphy {
+            renderCalligraphyStroke(stroke, style: style, color: color, in: &context)
+            return
+        }
 
         var path = Path()
-        let firstPoint = stroke.points[0]
-        path.move(to: CGPoint(x: firstPoint.x, y: firstPoint.y))
-
+        path.move(to: CGPoint(x: stroke.points[0].x, y: stroke.points[0].y))
         for point in stroke.points.dropFirst() {
             path.addLine(to: CGPoint(x: point.x, y: point.y))
         }
+        context.stroke(path, with: .color(color), lineWidth: style.baseWidth)
+    }
 
-        // context.transform is already applied, no need to transform path
-        let color = Color(hex: stroke.color)
-        context.stroke(
-            path,
-            with: .color(color),
-            lineWidth: stroke.width
-        )
+    private func renderCalligraphyStroke(_ stroke: Stroke, style: PenStyle, color: Color, in context: inout GraphicsContext) {
+        let nibAngle = Double.pi / 4
+        let points = stroke.points
+        for i in 0..<(points.count - 1) {
+            let p0 = CGPoint(x: points[i].x, y: points[i].y)
+            let p1 = CGPoint(x: points[i + 1].x, y: points[i + 1].y)
+            let segmentAngle = atan2(p1.y - p0.y, p1.x - p0.x)
+            let widthFactor = abs(cos(segmentAngle - nibAngle))
+            let width = style.minWidth + (style.maxWidth - style.minWidth) * widthFactor
+            var segmentPath = Path()
+            segmentPath.move(to: p0)
+            segmentPath.addLine(to: p1)
+            context.stroke(segmentPath, with: .color(color), lineWidth: width)
+        }
     }
 
     private func handleAddImageTapped() {
@@ -545,5 +516,12 @@ extension Color {
         let blue = Double(rgb & 0xFF) / 255.0
 
         self.init(red: red, green: green, blue: blue)
+    }
+}
+
+extension GraphicsContext {
+    mutating func applyPenStyle(_ style: PenStyle) {
+        opacity = style.opacity
+        blendMode = style.usesScreenBlend ? .screen : .normal
     }
 }

--- a/SharedDrawing/Features/Canvas/CanvasViewModel.swift
+++ b/SharedDrawing/Features/Canvas/CanvasViewModel.swift
@@ -13,6 +13,13 @@ class CanvasViewModel {
     var rotationAngle: Double = 0.0  // Radians
     var canUndo: Bool { !undoStack.isEmpty || lastClearedStrokes != nil }
     var isAnonymous: Bool { authService.isAnonymous }
+    var selectedPenStyle: PenStyle {
+        didSet {
+            UserDefaults.standard.set(selectedPenStyle.rawValue, forKey: Self.penStyleDefaultsKey)
+        }
+    }
+
+    private static let penStyleDefaultsKey = "com.shareddrawing.selectedPenStyle"
 
     let repository: CanvasRepository
     private let authService: AuthService
@@ -25,6 +32,8 @@ class CanvasViewModel {
         self.canvasId = canvasId
         self.repository = repository
         self.authService = authService
+        let savedRaw = UserDefaults.standard.string(forKey: Self.penStyleDefaultsKey)
+        self.selectedPenStyle = savedRaw.flatMap(PenStyle.init(rawValue:)) ?? .default
         setupStrokeListener()
     }
 
@@ -156,10 +165,11 @@ class CanvasViewModel {
             id: UUID().uuidString,
             userId: authService.currentUserID ?? "anonymous",
             color: currentColor,
-            width: 2.0,
+            width: selectedPenStyle.baseWidth,
             points: [StrokePoint(x: Double(point.x), y: Double(point.y), t: 0)],
             isComplete: false,
-            createdAt: now
+            createdAt: now,
+            style: selectedPenStyle.rawValue
         )
     }
 

--- a/SharedDrawing/Features/Canvas/CanvasViewModel.swift
+++ b/SharedDrawing/Features/Canvas/CanvasViewModel.swift
@@ -1,5 +1,8 @@
 import Foundation
 import Observation
+import os.log
+
+private let logger = Logger(subsystem: "io.github.nicechester.shareddrawing", category: "Canvas")
 
 @Observable
 class CanvasViewModel {
@@ -111,9 +114,9 @@ class CanvasViewModel {
                     if url != backgroundImageUrl {
                         backgroundImageUrl = url
                         if let url = url {
-                            print("📸 Loaded background image URL: \(url)")
+                            logger.debug("Loaded background image URL: \(url)")
                         } else {
-                            print("📸 Background image cleared")
+                            logger.debug("Background image cleared")
                         }
                     }
 
@@ -121,11 +124,11 @@ class CanvasViewModel {
                     if let dimensions = try await repository.getBackgroundImageDimensions(for: canvasId) {
                         if imageSize != dimensions {
                             imageSize = dimensions
-                            print("📐 Loaded image dimensions: \(dimensions)")
+                            logger.debug("Loaded image dimensions: \(dimensions.width)x\(dimensions.height)")
                         }
                     }
                 } catch {
-                    print("⚠️ Failed to load background image metadata: \(error)")
+                    logger.warning("Failed to load background image metadata: \(error)")
                 }
 
                 // Check for updates every 2 seconds
@@ -180,7 +183,7 @@ class CanvasViewModel {
             try await repository.addStroke(finalStroke, to: canvasId)
             undoStack.push(finalStroke)
         } catch {
-            print("Error submitting stroke: \(error)")
+            logger.error("Error submitting stroke: \(error)")
         }
     }
 
@@ -191,14 +194,14 @@ class CanvasViewModel {
                 do {
                     try await repository.addStroke(stroke, to: canvasId)
                 } catch {
-                    print("❌ Error undoing clear: \(error)")
+                    logger.error("Error undoing clear: \(error)")
                 }
             }
         } else if let stroke = undoStack.pop() {
             do {
                 try await repository.removeStroke(id: stroke.id, from: canvasId)
             } catch {
-                print("❌ Error undoing stroke: \(error)")
+                logger.error("Error undoing stroke: \(error)")
             }
         }
     }
@@ -225,7 +228,7 @@ class CanvasViewModel {
         if let width = width, let height = height {
             self.imageSize = CGSize(width: width, height: height)
         }
-        print("✅ Background image URL updated: \(imageUrl)")
+        logger.info("Background image URL updated: \(imageUrl)")
     }
 
     deinit {

--- a/SharedDrawing/Features/Canvas/ColorPalettePicker.swift
+++ b/SharedDrawing/Features/Canvas/ColorPalettePicker.swift
@@ -2,82 +2,198 @@ import SwiftUI
 
 struct ColorPalettePicker: View {
     @Binding var selectedColor: String
-    var vertical: Bool = false
+    @Binding var selectedPenStyle: PenStyle
+    @Binding var isPointerMode: Bool
     var onImagePickerTapped: (() -> Void)?
+    var onClearTapped: () -> Void
 
-    private let colors: [(name: String, hex: String)] = [
-        ("Black", "#000000"),
-        ("Red", "#FF3B30"),
-        ("Green", "#34C759"),
-        ("Blue", "#007AFF"),
-        ("Yellow", "#FFCC00"),
-    ]
+    @State private var isExpanded: Bool = false
+    @State private var showingStyleSubmenu: Bool = false
+    @State private var showClearConfirmation: Bool = false
 
     var body: some View {
-        if vertical {
-            VStack(spacing: 12) {
-                ForEach(colors, id: \.hex) { color in
-                    Button(action: { selectedColor = color.hex }) {
-                        Circle()
-                            .fill(Color(hex: color.hex))
-                            .frame(width: 32, height: 32)
-                            .overlay(
-                                Circle()
-                                    .stroke(Color.white, lineWidth: selectedColor == color.hex ? 3 : 0)
-                            )
-                    }
-                    .accessibilityLabel(color.name)
-                }
-
-                Divider()
-                    .padding(.vertical, 4)
-
-                Button(action: { onImagePickerTapped?() }) {
-                    Image(systemName: "photo.fill")
-                        .font(.system(size: 18))
-                        .foregroundColor(.blue)
-                        .frame(width: 32, height: 32)
-                }
-                .accessibilityLabel("Add background image")
+        VStack(alignment: .leading, spacing: 0) {
+            if isExpanded {
+                expandedContent
+            } else {
+                collapsedContent
             }
-            .frame(width: 48)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 12)
-            .background(Color(.systemGray6))
-        } else {
-            HStack(spacing: 8) {
-                ForEach(colors, id: \.hex) { color in
-                    Button(action: { selectedColor = color.hex }) {
-                        Circle()
-                            .fill(Color(hex: color.hex))
-                            .frame(width: 24, height: 24)
-                            .overlay(
-                                Circle()
-                                    .stroke(Color.white, lineWidth: selectedColor == color.hex ? 3 : 0)
-                            )
-                    }
-                    .accessibilityLabel(color.name)
-                }
-
-                Button(action: { onImagePickerTapped?() }) {
-                    Image(systemName: "photo.fill")
-                        .font(.system(size: 14))
-                        .foregroundColor(.blue)
-                }
-                .accessibilityLabel("Add background image")
-
-                Spacer()
+        }
+        .background(Color(.systemGray6))
+        .cornerRadius(8)
+        .alert("Clear All Strokes?", isPresented: $showClearConfirmation) {
+            Button("Cancel", role: .cancel) { isExpanded = false }
+            Button("Clear", role: .destructive) {
+                onClearTapped()
+                isExpanded = false
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 4)
+        } message: {
+            Text("This will permanently delete all drawings on this canvas. This action cannot be undone.")
         }
     }
-}
 
-#Preview {
-    @Previewable @State var selectedColor = "#000000"
-    ColorPalettePicker(selectedColor: $selectedColor, onImagePickerTapped: {
-        print("Image picker tapped")
-    })
-        .padding()
+    private var collapsedContent: some View {
+        Group {
+            if isPointerMode {
+                pointerCollapsedView
+            } else {
+                penCollapsedView
+            }
+        }
+        .padding(8)
+        .accessibilityLabel(isPointerMode ? "Pointer mode — tap to expand palette" : "Expand palette")
+    }
+
+    private var pointerCollapsedView: some View {
+        Button(action: { isExpanded = true }) {
+            Image(systemName: "hand.point.up.fill")
+                .font(.system(size: 20))
+                .foregroundColor(.blue)
+                .frame(width: 40, height: 40)
+        }
+    }
+
+    private var penCollapsedView: some View {
+        Button(action: { isExpanded = true }) {
+            ZStack(alignment: .bottomTrailing) {
+                Circle()
+                    .fill(Color(hex: selectedColor))
+                    .frame(width: 40, height: 40)
+                    .overlay(Circle().stroke(Color.white, lineWidth: 2))
+                Image(systemName: "pencil")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(4)
+                    .background(Circle().fill(Color.blue))
+                    .offset(x: 4, y: 4)
+            }
+        }
+    }
+
+    private var expandedContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if showingStyleSubmenu {
+                styleSubmenuContent
+            } else {
+                mainPaletteContent
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+    }
+
+    private var mainPaletteContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Color row
+            HStack(spacing: 8) {
+                ForEach(["#000000", "#FF3B30", "#00C7BE", "#FFCC00", "#5856D6"], id: \.self) { color in
+                    Button(action: {
+                        selectedColor = color
+                        isExpanded = false
+                    }) {
+                        Circle()
+                            .fill(Color(hex: color))
+                            .frame(width: 24, height: 24)
+                            .overlay(
+                                Circle().stroke(selectedColor == color ? Color.white : Color.clear, lineWidth: 2)
+                            )
+                    }
+                }
+                Spacer()
+            }
+
+            Divider()
+
+            // Pen row
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Image(systemName: "pencil")
+                        Text(selectedPenStyle.displayName)
+                        if !isPointerMode {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                    .contentShape(Rectangle())
+                }
+                Spacer()
+                Button(action: { showingStyleSubmenu = true }) {
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(.gray)
+                }
+            }
+            .padding(.vertical, 8)
+            .onTapGesture {
+                isPointerMode = false
+                isExpanded = false
+            }
+
+            // Pointer row
+            HStack {
+                Image(systemName: "hand.point.up.fill")
+                Text("Pointer")
+                if isPointerMode {
+                    Image(systemName: "checkmark")
+                }
+                Spacer()
+            }
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                isPointerMode = true
+                isExpanded = false
+            }
+
+            Divider()
+
+            // Image row
+            HStack {
+                Image(systemName: "photo.fill")
+                Text("Add Image")
+                Spacer()
+            }
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                onImagePickerTapped?()
+                isExpanded = false
+            }
+
+            // Clear row
+            HStack {
+                Image(systemName: "trash")
+                    .foregroundColor(.red)
+                Text("Clear")
+                    .foregroundColor(.red)
+                Spacer()
+            }
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                showClearConfirmation = true
+            }
+        }
+    }
+
+    private var styleSubmenuContent: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Button(action: { showingStyleSubmenu = false }) {
+                HStack {
+                    Image(systemName: "chevron.left")
+                    Text("Back")
+                }
+            }
+            .padding(.bottom, 8)
+
+            PenStyleMenu(
+                selectedStyle: $selectedPenStyle,
+                previewColor: selectedColor,
+                onSelect: {
+                    isPointerMode = false
+                    showingStyleSubmenu = false
+                    isExpanded = false
+                }
+            )
+        }
+    }
 }

--- a/SharedDrawing/Features/Canvas/ColorPalettePicker.swift
+++ b/SharedDrawing/Features/Canvas/ColorPalettePicker.swift
@@ -89,6 +89,7 @@ struct ColorPalettePicker: View {
                 ForEach(["#000000", "#FF3B30", "#00C7BE", "#FFCC00", "#5856D6"], id: \.self) { color in
                     Button(action: {
                         selectedColor = color
+                        isPointerMode = false
                         isExpanded = false
                     }) {
                         Circle()

--- a/SharedDrawing/Features/Canvas/PenStyleMenu.swift
+++ b/SharedDrawing/Features/Canvas/PenStyleMenu.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct PenStyleMenu: View {
+    @Binding var selectedStyle: PenStyle
+    let previewColor: String
+    var onSelect: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(PenStyle.allCases) { style in
+                Button {
+                    selectedStyle = style
+                    onSelect()
+                } label: {
+                    HStack(spacing: 12) {
+                        PenStylePreview(style: style, color: previewColor)
+                            .frame(width: 40, height: 40)
+                        Text(style.displayName)
+                        Spacer()
+                        if style == selectedStyle {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.vertical, 8)
+        .frame(width: 220)
+    }
+}
+
+private struct PenStylePreview: View {
+    let style: PenStyle
+    let color: String
+
+    var body: some View {
+        Canvas { context, size in
+            var path = Path()
+            path.move(to: CGPoint(x: 4, y: size.height - 8))
+            path.addQuadCurve(
+                to: CGPoint(x: size.width - 4, y: 8),
+                control: CGPoint(x: size.width / 2, y: size.height / 2)
+            )
+            context.applyPenStyle(style)
+            context.stroke(path, with: .color(Color(hex: color)), lineWidth: style.maxWidth)
+        }
+    }
+}

--- a/SharedDrawing/SharedDrawingApp.swift
+++ b/SharedDrawing/SharedDrawingApp.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+import os.log
+
+private let logger = Logger(subsystem: "io.github.nicechester.shareddrawing", category: "App")
 import Firebase
 import GoogleSignIn
 
@@ -28,15 +31,15 @@ struct SharedDrawingApp: App {
                 }
             }
             .onOpenURL { url in
-                print("🔗 Received URL:", url.absoluteString)
+                logger.debug("Received URL: \(url.absoluteString)")
                 if GIDSignIn.sharedInstance.handle(url) {
                     return
                 }
                 if let canvasId = url.queryItemValue(for: "id") {
-                    print("🎯 Parsed Canvas ID:", canvasId)
+                    logger.info("Parsed Canvas ID: \(canvasId)")
                     deepLinkCanvasId = canvasId
                 } else {
-                    print("⚠️ Could not parse 'id' parameter from:", url)
+                    logger.warning("Could not parse 'id' parameter from: \(url)")
                 }
             }
         }


### PR DESCRIPTION
## Summary
Redesigned palette UI to consolidate tool selection (pen/pointer), pen styles, colors, image upload, and clear action into one elegant collapsible widget. Implements pen style selection with 5 distinct styles (ballpoint, marker, highlighter, calligraphy, pencil) with visually different widths and opacity.

## Key Changes
- **Palette redesign**: Collapsed to pointer icon (pointer mode) or colored circle + pen badge (pen mode)
- **Collapsed → expanded**: Tap to show color palette, pen/pointer buttons, pen style submenu, image & clear buttons
- **Auto-collapse**: Any selection immediately collapses palette for clean UX
- **Pen styles**: 5 styles with distinct widths (ballpoint 2pt, marker 4pt, highlighter 8pt, calligraphy 2-5pt, pencil 2.5pt)
- **Pen style submenu**: Long inline menu with live previews, accessible via chevron on pen row
- **Header cleanup**: Removed pen/pointer toggle, clear button, expand/collapse buttons
- **Clear action**: Moved to palette with confirmation alert
- **Cross-device sync**: Style field stored in Stroke for Firebase persistence

## Implementation Details
- **PenStyle.swift** (new): Enum with width/opacity/blend definitions
- **PenStyleMenu.swift** (new): Reusable pen style picker component
- **ColorPalettePicker.swift** (redesigned): Owns all palette state/interaction
- **Stroke.swift**: Added `style: String` field
- **CanvasViewModel.swift**: selectedPenStyle with UserDefaults persistence
- **FirebaseCanvasRepository.swift**: Encode/decode style with legacy fallback
- **CanvasView.swift**: Removed palette logic, simplified header

## User Flow
1. Collapsed palette shows current mode (pointer icon or pen+circle)
2. Tap palette → expands to show tools/colors
3. Select color → auto-collapse, color persists
4. Tap pen row main area → switch to pen mode, collapse
5. Tap pen row chevron → inline style menu (back button to main)
6. Select style → force pen mode, close menu, collapse palette
7. Tap pointer row → switch to pointer mode, collapse
8. Tap clear → confirmation alert (collapse after confirm/cancel)

## Test Plan
- [ ] Collapsed palette shows pointer icon when in pointer mode
- [ ] Collapsed palette shows colored circle + pen badge in pen mode
- [ ] Tap collapsed palette → expands
- [ ] Tap color → auto-collapse with new color selected
- [ ] Tap pen row main area → pen mode, collapse
- [ ] Tap pen row chevron → style submenu opens, palette stays expanded
- [ ] Select style → forces pen mode, closes submenu, collapses palette
- [ ] Tap pointer row → pointer mode, collapse
- [ ] Tap "Add Image" → image picker opens, palette collapses
- [ ] Tap "Clear" → alert appears, confirm/cancel both collapse
- [ ] Draw with each pen style → verify distinct visual differences
- [ ] Force-quit and relaunch → selected pen style persists
- [ ] Two-simulator test → pen style syncs to other user via Firebase
- [ ] Legacy strokes without style field → render as ballpoint

## Fixes #77