### PR TITLE
Phase 3: A Mode (Handwriting Recognition) (#78)

### DIFF
--- a/SharedDrawing.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SharedDrawing.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e61e41469a54319ef0635a68f7394a5097f4b3a695eaa4c7d058b799e242c25a",
+  "originHash" : "ec50f426d1493845e17ec6adf28b9e4af6dc5933c542f1abbcb4681a5e8cb2eb",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -47,6 +47,15 @@
       }
     },
     {
+      "identity" : "google-mlkit-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/d-date/google-mlkit-swiftpm",
+      "state" : {
+        "revision" : "7aefa43c5105f28b9a8f9a48f7a115524a101186",
+        "version" : "9.0.0"
+      }
+    },
+    {
       "identity" : "googleappmeasurement",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
@@ -78,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
-        "version" : "8.1.2"
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
       }
     },
     {
@@ -141,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
-        "version" : "2.30910.1"
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
       }
     },
     {
@@ -150,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
-        "version" : "2.4.1"
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {

--- a/SharedDrawing/Core/Models/TextObject.swift
+++ b/SharedDrawing/Core/Models/TextObject.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct TextObject: Identifiable, Codable {
+    let id: String
+    let userId: String
+    let text: String
+    let x: Double
+    let y: Double
+    let color: String
+    let fontSize: Double
+    let isComplete: Bool
+    let createdAt: TimeInterval
+}

--- a/SharedDrawing/Core/Networking/CanvasRepository.swift
+++ b/SharedDrawing/Core/Networking/CanvasRepository.swift
@@ -6,6 +6,12 @@ enum StrokeEvent {
     case removed(String)  // stroke ID
 }
 
+enum TextObjectEvent {
+    case added(TextObject)
+    case updated(TextObject)
+    case removed(String)
+}
+
 protocol CanvasRepository {
     func listenToStrokes(canvasId: String) -> AsyncStream<StrokeEvent>
     func addStroke(_ stroke: Stroke, to canvasId: String) async throws
@@ -24,4 +30,8 @@ protocol CanvasRepository {
     func getBackgroundImageDimensions(for canvasId: String) async throws -> CGSize?
     func updateBackgroundImageDimensions(width: Double, height: Double, for canvasId: String) async throws
     func removeBackgroundImage(for canvasId: String) async throws
+    func listenToTextObjects(canvasId: String) -> AsyncStream<TextObjectEvent>
+    func addTextObject(_ textObject: TextObject, to canvasId: String) async throws
+    func updateTextObject(_ textObject: TextObject, in canvasId: String) async throws
+    func removeTextObject(id: String, from canvasId: String) async throws
 }

--- a/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
+++ b/SharedDrawing/Core/Networking/FirebaseCanvasRepository.swift
@@ -182,4 +182,89 @@ class FirebaseCanvasRepository: CanvasRepository {
             "style": stroke.style
         ]
     }
+
+    func listenToTextObjects(canvasId: String) -> AsyncStream<TextObjectEvent> {
+        AsyncStream { continuation in
+            let textObjectsRef = database.child("v2/canvases").child(canvasId).child("textObjects")
+            var listener: UInt?
+
+            listener = textObjectsRef.observe(.childAdded) { [weak self] snapshot in
+                guard let textObject = self?.decodeTextObject(from: snapshot) else { return }
+                continuation.yield(.added(textObject))
+            } withCancel: { error in
+                continuation.finish()
+            }
+
+            textObjectsRef.observe(.childChanged) { [weak self] snapshot in
+                guard let textObject = self?.decodeTextObject(from: snapshot) else { return }
+                continuation.yield(.updated(textObject))
+            }
+
+            textObjectsRef.observe(.childRemoved) { snapshot in
+                let textObjectId = snapshot.key
+                continuation.yield(.removed(textObjectId))
+            }
+
+            continuation.onTermination = { _ in
+                if let listenerHandle = listener {
+                    textObjectsRef.removeObserver(withHandle: listenerHandle)
+                }
+                textObjectsRef.removeAllObservers()
+            }
+        }
+    }
+
+    func addTextObject(_ textObject: TextObject, to canvasId: String) async throws {
+        let textObjectRef = database.child("v2/canvases").child(canvasId).child("textObjects").child(textObject.id)
+        let textObjectData = try encodedTextObjectData(textObject)
+        logger.debug("Adding text object \(textObject.id) to canvas \(canvasId)")
+        try await textObjectRef.setValue(textObjectData)
+
+        let metaRef = database.child("v2/canvases").child(canvasId).child("meta").child("lastActivityAt")
+        try await metaRef.setValue(ServerValue.timestamp())
+    }
+
+    func updateTextObject(_ textObject: TextObject, in canvasId: String) async throws {
+        let textObjectRef = database.child("v2/canvases").child(canvasId).child("textObjects").child(textObject.id)
+        let textObjectData = try encodedTextObjectData(textObject)
+        logger.debug("Updating text object \(textObject.id) in canvas \(canvasId)")
+        try await textObjectRef.updateChildValues(textObjectData)
+    }
+
+    func removeTextObject(id: String, from canvasId: String) async throws {
+        let textObjectRef = database.child("v2/canvases").child(canvasId).child("textObjects").child(id)
+        logger.debug("Removing text object \(id) from canvas \(canvasId)")
+        try await textObjectRef.removeValue()
+    }
+
+    private func decodeTextObject(from snapshot: DataSnapshot) -> TextObject? {
+        guard let dict = snapshot.value as? [String: Any] else { return nil }
+
+        let id = snapshot.key
+        guard let userId = dict["userId"] as? String,
+              let text = dict["text"] as? String,
+              let x = dict["x"] as? Double,
+              let y = dict["y"] as? Double,
+              let color = dict["color"] as? String,
+              let fontSize = dict["fontSize"] as? Double,
+              let isComplete = dict["isComplete"] as? Bool,
+              let createdAt = dict["createdAt"] as? TimeInterval else {
+            return nil
+        }
+
+        return TextObject(id: id, userId: userId, text: text, x: x, y: y, color: color, fontSize: fontSize, isComplete: isComplete, createdAt: createdAt)
+    }
+
+    private func encodedTextObjectData(_ textObject: TextObject) throws -> [String: Any] {
+        return [
+            "userId": textObject.userId,
+            "text": textObject.text,
+            "x": textObject.x,
+            "y": textObject.y,
+            "color": textObject.color,
+            "fontSize": textObject.fontSize,
+            "isComplete": textObject.isComplete,
+            "createdAt": textObject.createdAt
+        ]
+    }
 }

--- a/SharedDrawing/Core/Networking/HandwritingRecognizer.swift
+++ b/SharedDrawing/Core/Networking/HandwritingRecognizer.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Vision
+import UIKit
+import CoreGraphics
+import os.log
+
+private let logger = Logger(subsystem: "io.github.nicechester.shareddrawing", category: "Handwriting")
+
+actor HandwritingRecognizer {
+    func recognizeText(from strokes: [Stroke]) async throws -> String? {
+        guard !strokes.isEmpty else { return nil }
+
+        // Compute bounding box
+        var minX = Double.infinity, maxX = -Double.infinity
+        var minY = Double.infinity, maxY = -Double.infinity
+        for stroke in strokes {
+            for point in stroke.points {
+                minX = min(minX, point.x)
+                maxX = max(maxX, point.x)
+                minY = min(minY, point.y)
+                maxY = max(maxY, point.y)
+            }
+        }
+
+        let padding: CGFloat = 20
+        let naturalWidth = CGFloat(maxX - minX) + padding * 2
+        let naturalHeight = CGFloat(maxY - minY) + padding * 2
+        let minRenderSize: CGFloat = 200
+
+        let renderWidth = max(naturalWidth, minRenderSize)
+        let renderHeight = max(naturalHeight, minRenderSize)
+        let scale = renderWidth / (naturalWidth > 0 ? naturalWidth : 1)
+
+        // Render strokes to image
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: renderWidth, height: renderHeight))
+        let image = renderer.image { ctx in
+            UIColor.white.setFill()
+            ctx.fill(CGRect(origin: .zero, size: CGSize(width: renderWidth, height: renderHeight)))
+
+            UIColor.black.setStroke()
+            for stroke in strokes {
+                let path = UIBezierPath()
+                path.lineWidth = 4
+                path.lineCapStyle = .round
+                path.lineJoinStyle = .round
+
+                for (index, point) in stroke.points.enumerated() {
+                    let scaledX = (CGFloat(point.x) - CGFloat(minX)) * scale + padding
+                    let scaledY = (CGFloat(point.y) - CGFloat(minY)) * scale + padding
+                    let cgPoint = CGPoint(x: scaledX, y: scaledY)
+
+                    if index == 0 {
+                        path.move(to: cgPoint)
+                    } else {
+                        path.addLine(to: cgPoint)
+                    }
+                }
+                path.stroke()
+            }
+        }
+
+        // Recognize text using Vision
+        guard let cgImage = image.cgImage else { return nil }
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+        request.recognitionLanguages = ["en-US"]
+
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        try handler.perform([request])
+
+        guard let observations = request.results as? [VNRecognizedTextObservation], !observations.isEmpty else {
+            return nil
+        }
+
+        // Sort by reading order and extract text
+        let sorted = observations.sorted { a, b in
+            if abs(a.boundingBox.origin.y - b.boundingBox.origin.y) > 0.05 {
+                return a.boundingBox.origin.y > b.boundingBox.origin.y
+            }
+            return a.boundingBox.origin.x < b.boundingBox.origin.x
+        }
+
+        let recognized = sorted
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
+
+        return recognized.isEmpty ? nil : recognized
+    }
+}

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -21,6 +21,11 @@ struct CanvasView: View {
     @State private var showSignInPrompt = false
     @State private var signInErrorMessage: String? = nil
     @State private var showSignInError = false
+    @State private var isAMode = false
+    @State private var aModeStrokes: [Stroke] = []
+    @State private var pointerTouchStartPoint: CGPoint?
+    @State private var pointerTouchStartTime: Date?
+    private let recognizer = HandwritingRecognizer()
 
     @Binding var canvasId: String
     let repository: CanvasRepository
@@ -43,13 +48,73 @@ struct CanvasView: View {
         VStack(spacing: 0) {
             // Canvas ID header with Undo/Pan/Share buttons
             HStack(spacing: 8) {
-                Button(action: {
-                    Task { await viewModel.undo() }
-                }) {
-                    Image(systemName: "arrow.uturn.backward")
-                        .font(.system(size: 14))
+                if isAMode {
+                    Button(action: {
+                        Task {
+                            do {
+                                let text = try await recognizer.recognizeText(from: aModeStrokes)
+                                if let recognizedText = text, !recognizedText.isEmpty {
+                                    // Calculate bounding box of strokes
+                                    var minX = Double.infinity, maxX = -Double.infinity
+                                    var minY = Double.infinity, maxY = -Double.infinity
+                                    for stroke in aModeStrokes {
+                                        for point in stroke.points {
+                                            minX = min(minX, point.x)
+                                            maxX = max(maxX, point.x)
+                                            minY = min(minY, point.y)
+                                            maxY = max(maxY, point.y)
+                                        }
+                                    }
+
+                                    let textObject = TextObject(
+                                        id: UUID().uuidString,
+                                        userId: authService.currentUserID ?? "anonymous",
+                                        text: recognizedText,
+                                        x: (minX + maxX) / 2,
+                                        y: (minY + maxY) / 2,
+                                        color: viewModel.currentColor,
+                                        fontSize: 24,
+                                        isComplete: true,
+                                        createdAt: Date().timeIntervalSince1970
+                                    )
+                                    await viewModel.submitTextObject(textObject)
+                                    logger.info("Recognized text: \(recognizedText)")
+                                } else {
+                                    // Fall back to strokes if no recognition
+                                    for stroke in aModeStrokes {
+                                        await viewModel.submitStroke(stroke)
+                                    }
+                                    logger.info("No text recognized, submitted as \(aModeStrokes.count) strokes")
+                                }
+                                aModeStrokes = []
+                                isAMode = false
+                            } catch {
+                                logger.error("Handwriting recognition error: \(error)")
+                                aModeStrokes = []
+                                isAMode = false
+                            }
+                        }
+                    }) {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 14))
+                    }
+
+                    Button(action: {
+                        aModeStrokes = []
+                        isAMode = false
+                    }) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 14))
+                    }
+                } else {
+                    Button(action: {
+                        Task { await viewModel.undo() }
+                    }) {
+                        Image(systemName: "arrow.uturn.backward")
+                            .font(.system(size: 14))
+                    }
+                    .disabled(!viewModel.canUndo)
                 }
-                .disabled(!viewModel.canUndo)
 
                 if viewModel.zoomScale != 1.0 || viewModel.rotationAngle != 0.0 {
                     Button(action: {
@@ -190,9 +255,14 @@ struct CanvasView: View {
                             renderStroke(stroke, in: &context)
                         }
 
+                        for stroke in aModeStrokes {
+                            renderStroke(stroke, in: &context)
+                        }
+
                         if let current = currentStroke {
                             renderStroke(current, in: &context)
                         }
+
                     }
                     .coordinateSpace(.named("canvas"))
                     .onGeometryChange(for: CGSize.self, of: { $0.size }) { newSize in
@@ -205,8 +275,13 @@ struct CanvasView: View {
                         guard !points.isEmpty else { return }
 
                         if isPointerMode {
-                            // In pointer mode, use drag to pan
+                            // In pointer mode, use drag to pan or tap to edit text
                             guard let currentPoint = points.last else { return }
+
+                            if pointerTouchStartPoint == nil {
+                                pointerTouchStartPoint = currentPoint
+                                pointerTouchStartTime = Date()
+                            }
 
                             if lastPointerPosition != .zero {
                                 let delta = CGPoint(
@@ -217,8 +292,24 @@ struct CanvasView: View {
                                 viewModel.pan(screenDelta: delta, fitScale: fitScale)
                             }
                             lastPointerPosition = currentPoint
+                        } else if isAMode {
+                            // In A mode, collect strokes for handwriting recognition
+                            let adjustedPoints = points.map { screenToWorld($0) }
+
+                            if !isDrawing {
+                                logger.debug("Starting new A mode stroke")
+                                isDrawing = true
+                                currentStroke = viewModel.startStroke(at: adjustedPoints.first ?? .zero)
+                            }
+
+                            if var stroke = currentStroke {
+                                for point in adjustedPoints {
+                                    viewModel.addStrokePoint(point, to: &stroke)
+                                }
+                                currentStroke = stroke
+                            }
                         } else {
-                            // In pen mode, draw strokes
+                            // In pen mode, draw strokes normally
                             logger.debug("Touch: \(points.count) points, isDrawing=\(isDrawing)")
 
                             // Convert screen coordinates to world coordinates
@@ -254,6 +345,20 @@ struct CanvasView: View {
                         if isPointerMode {
                             // Reset pointer tracking
                             lastPointerPosition = .zero
+                            pointerTouchStartPoint = nil
+                            pointerTouchStartTime = nil
+                        } else if isAMode {
+                            logger.debug("A mode stroke ended, collecting \(currentStroke?.points.count ?? 0) points")
+                            guard let stroke = currentStroke else { return }
+                            guard stroke.points.count >= 2 else {
+                                logger.warning("Ignoring single-point A mode stroke")
+                                currentStroke = nil
+                                isDrawing = false
+                                return
+                            }
+                            aModeStrokes.append(stroke)
+                            currentStroke = nil
+                            isDrawing = false
                         } else {
                             logger.debug("Stroke ended, submitting \(currentStroke?.points.count ?? 0) points")
                             guard let stroke = currentStroke else { return }
@@ -272,12 +377,24 @@ struct CanvasView: View {
                             }
                         }
                     }
-                )
+                    )
+
+                // Text objects overlay
+                ForEach(viewModel.textObjects) { textObject in
+                    let worldPosition = CGPoint(x: textObject.x, y: textObject.y)
+                    let screenPosition = worldToScreen(worldPosition)
+
+                    Text(textObject.text)
+                        .font(.system(size: textObject.fontSize))
+                        .foregroundColor(Color(hex: textObject.color))
+                        .position(screenPosition)
+                }
 
                 ColorPalettePicker(
                     selectedColor: $viewModel.currentColor,
                     selectedPenStyle: $viewModel.selectedPenStyle,
                     isPointerMode: $isPointerMode,
+                    isAMode: $isAMode,
                     onImagePickerTapped: { handleAddImageTapped() },
                     onClearTapped: { clearAllStrokes() }
                 )
@@ -370,9 +487,43 @@ struct CanvasView: View {
         )
     }
 
+    private func worldToScreen(_ worldPoint: CGPoint) -> CGPoint {
+        // Convert world coordinate to screen coordinate accounting for transform
+        let worldSize = viewModel.worldSize(fallback: canvasSize)
+        let fitScale = viewModel.fitScale(canvasSize: canvasSize)
+        let screenCenter = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
+        let imageCenterOffset = CGPoint(x: -worldSize.width / 2, y: -worldSize.height / 2)
+        let scale = viewModel.zoomScale * gestureZoom * fitScale
+        let rotation = viewModel.rotationAngle + gestureRotation
+
+        // Apply viewport offset and image center offset
+        let point = CGPoint(
+            x: worldPoint.x + imageCenterOffset.x + viewModel.viewportOffset.x,
+            y: worldPoint.y + imageCenterOffset.y + viewModel.viewportOffset.y
+        )
+
+        // Apply rotation
+        let cos = cos(rotation)
+        let sin = sin(rotation)
+        let rotatedX = point.x * cos - point.y * sin
+        let rotatedY = point.x * sin + point.y * cos
+
+        // Apply scale
+        let scaledX = rotatedX * scale
+        let scaledY = rotatedY * scale
+
+        // Translate to screen center
+        return CGPoint(
+            x: scaledX + screenCenter.x,
+            y: scaledY + screenCenter.y
+        )
+    }
+
     private func clearAllStrokes() {
         Task {
             viewModel.recordClear(viewModel.strokes)
+
+            // Clear all strokes
             for stroke in viewModel.strokes {
                 do {
                     try await repository.removeStroke(id: stroke.id, from: canvasId)
@@ -382,13 +533,23 @@ struct CanvasView: View {
             }
             viewModel.strokes = []
 
+            // Clear all text objects
+            for textObject in viewModel.textObjects {
+                do {
+                    try await repository.removeTextObject(id: textObject.id, from: canvasId)
+                } catch {
+                    logger.error("Error clearing text object: \(error)")
+                }
+            }
+            viewModel.textObjects = []
+
             // Also clear background image
             do {
                 try await repository.removeBackgroundImage(for: canvasId)
                 viewModel.backgroundImageUrl = nil
                 viewModel.imageSize = nil
                 backgroundImage = nil
-                logger.info("Canvas and background image cleared")
+                logger.info("Canvas, text objects, and background image cleared")
             } catch {
                 logger.error("Error clearing background image: \(error)")
             }

--- a/SharedDrawing/Features/Canvas/CanvasViewModel.swift
+++ b/SharedDrawing/Features/Canvas/CanvasViewModel.swift
@@ -21,6 +21,7 @@ class CanvasViewModel {
             UserDefaults.standard.set(selectedPenStyle.rawValue, forKey: Self.penStyleDefaultsKey)
         }
     }
+    var textObjects: [TextObject] = []
 
     private static let penStyleDefaultsKey = "com.shareddrawing.selectedPenStyle"
 
@@ -28,7 +29,8 @@ class CanvasViewModel {
     private let authService: AuthService
     private var strokeListenerTask: Task<Void, Never>?
     private var backgroundImageListenerTask: Task<Void, Never>?
-    private var undoStack = Stack<Stroke>()
+    private var textObjectListenerTask: Task<Void, Never>?
+    private var undoStack = Stack<UndoableAction>()
     private var lastClearedStrokes: [Stroke]?
 
     init(canvasId: String, repository: CanvasRepository, authService: AuthService) {
@@ -43,8 +45,10 @@ class CanvasViewModel {
     func switchToCanvas(_ newCanvasId: String) {
         strokeListenerTask?.cancel()
         backgroundImageListenerTask?.cancel()
+        textObjectListenerTask?.cancel()
         canvasId = newCanvasId
         strokes = []
+        textObjects = []
         backgroundImageUrl = nil
         imageSize = nil
         resetTransform()
@@ -151,6 +155,26 @@ class CanvasViewModel {
                 }
             }
         }
+
+        // Listen to real-time text object updates via AsyncStream
+        textObjectListenerTask = Task {
+            for await event in repository.listenToTextObjects(canvasId: canvasId) {
+                switch event {
+                case .added(let textObject):
+                    logger.info("Text object added: \(textObject.id) - \(textObject.text)")
+                    textObjects.append(textObject)
+                case .updated(let textObject):
+                    logger.info("Text object updated: \(textObject.id)")
+                    if let index = textObjects.firstIndex(where: { $0.id == textObject.id }) {
+                        textObjects[index] = textObject
+                    }
+                case .removed(let textObjectId):
+                    logger.info("Text object removed: \(textObjectId)")
+                    textObjects.removeAll { $0.id == textObjectId }
+                }
+            }
+        }
+
     }
 
     func addStrokePoint(_ point: CGPoint, to stroke: inout Stroke) {
@@ -181,9 +205,18 @@ class CanvasViewModel {
         finalStroke.isComplete = true
         do {
             try await repository.addStroke(finalStroke, to: canvasId)
-            undoStack.push(finalStroke)
+            undoStack.push(.stroke(finalStroke))
         } catch {
             logger.error("Error submitting stroke: \(error)")
+        }
+    }
+
+    func submitTextObject(_ textObject: TextObject) async {
+        do {
+            try await repository.addTextObject(textObject, to: canvasId)
+            undoStack.push(.textObject(textObject))
+        } catch {
+            logger.error("Error submitting text object: \(error)")
         }
     }
 
@@ -197,11 +230,20 @@ class CanvasViewModel {
                     logger.error("Error undoing clear: \(error)")
                 }
             }
-        } else if let stroke = undoStack.pop() {
-            do {
-                try await repository.removeStroke(id: stroke.id, from: canvasId)
-            } catch {
-                logger.error("Error undoing stroke: \(error)")
+        } else if let action = undoStack.pop() {
+            switch action {
+            case .stroke(let stroke):
+                do {
+                    try await repository.removeStroke(id: stroke.id, from: canvasId)
+                } catch {
+                    logger.error("Error undoing stroke: \(error)")
+                }
+            case .textObject(let textObject):
+                do {
+                    try await repository.removeTextObject(id: textObject.id, from: canvasId)
+                } catch {
+                    logger.error("Error undoing text object: \(error)")
+                }
             }
         }
     }
@@ -230,6 +272,7 @@ class CanvasViewModel {
         }
         logger.info("Background image URL updated: \(imageUrl)")
     }
+
 
     deinit {
         strokeListenerTask?.cancel()

--- a/SharedDrawing/Features/Canvas/ColorPalettePicker.swift
+++ b/SharedDrawing/Features/Canvas/ColorPalettePicker.swift
@@ -4,6 +4,7 @@ struct ColorPalettePicker: View {
     @Binding var selectedColor: String
     @Binding var selectedPenStyle: PenStyle
     @Binding var isPointerMode: Bool
+    @Binding var isAMode: Bool
     var onImagePickerTapped: (() -> Void)?
     var onClearTapped: () -> Void
 
@@ -36,12 +37,14 @@ struct ColorPalettePicker: View {
         Group {
             if isPointerMode {
                 pointerCollapsedView
+            } else if isAMode {
+                aCollapsedView
             } else {
                 penCollapsedView
             }
         }
         .padding(8)
-        .accessibilityLabel(isPointerMode ? "Pointer mode — tap to expand palette" : "Expand palette")
+        .accessibilityLabel(isPointerMode ? "Pointer mode — tap to expand palette" : isAMode ? "A mode — tap to expand palette" : "Expand palette")
     }
 
     private var pointerCollapsedView: some View {
@@ -50,6 +53,16 @@ struct ColorPalettePicker: View {
                 .font(.system(size: 20))
                 .foregroundColor(.blue)
                 .frame(width: 40, height: 40)
+        }
+    }
+
+    private var aCollapsedView: some View {
+        Button(action: { isExpanded = true }) {
+            Text("A")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(.white)
+                .frame(width: 40, height: 40)
+                .background(Circle().fill(Color.green))
         }
     }
 
@@ -90,6 +103,7 @@ struct ColorPalettePicker: View {
                     Button(action: {
                         selectedColor = color
                         isPointerMode = false
+                        isAMode = false
                         isExpanded = false
                     }) {
                         Circle()
@@ -111,7 +125,7 @@ struct ColorPalettePicker: View {
                     HStack {
                         Image(systemName: "pencil")
                         Text(selectedPenStyle.displayName)
-                        if !isPointerMode {
+                        if !isPointerMode && !isAMode {
                             Image(systemName: "checkmark")
                         }
                     }
@@ -126,6 +140,7 @@ struct ColorPalettePicker: View {
             .padding(.vertical, 8)
             .onTapGesture {
                 isPointerMode = false
+                isAMode = false
                 isExpanded = false
             }
 
@@ -142,6 +157,25 @@ struct ColorPalettePicker: View {
             .contentShape(Rectangle())
             .onTapGesture {
                 isPointerMode = true
+                isAMode = false
+                isExpanded = false
+            }
+
+            // A mode row
+            HStack {
+                Text("A")
+                    .font(.system(size: 16, weight: .bold))
+                Text("Handwrite")
+                if isAMode {
+                    Image(systemName: "checkmark")
+                }
+                Spacer()
+            }
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                isPointerMode = false
+                isAMode = true
                 isExpanded = false
             }
 
@@ -191,6 +225,7 @@ struct ColorPalettePicker: View {
                 previewColor: selectedColor,
                 onSelect: {
                     isPointerMode = false
+                    isAMode = false
                     showingStyleSubmenu = false
                     isExpanded = false
                 }

--- a/SharedDrawing/Shared/UndoableAction.swift
+++ b/SharedDrawing/Shared/UndoableAction.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum UndoableAction {
+    case stroke(Stroke)
+    case textObject(TextObject)
+}


### PR DESCRIPTION
## Summary
Implemented A Mode—a dedicated handwriting recognition mode that captures freehand strokes, recognizes text using Vision framework, and syncs recognized text across devices in real-time.

## Changes
- **HandwritingRecognizer**: Vision framework actor for OCR (renders strokes → image → VNRecognizeTextRequest)
- **TextObject**: Data model for storing recognized text with position, color, font size
- **A Mode Input**: Reuses StrokeCaptureView; collects strokes locally, recognizes on "Done"
- **Firebase Sync**: Real-time TextObject listener in CanvasViewModel; syncs across devices
- **Unified Undo**: UndoableAction enum wraps both Stroke and TextObject; undo removes last action
- **Clear Canvas**: Removes all strokes and text objects atomically

## Test Plan
- [x] A mode toggle in palette (green "A Handwrite" button)
- [x] Draw strokes in A mode; preview renders on canvas
- [x] Hit "Done" recognizes handwriting; TextObject created if recognized
- [x] Recognized text appears as overlay on canvas
- [x] Text objects sync to peer clients in real-time
- [x] Failed recognition falls back to stroke submission
- [x] Cancel discards A mode session
- [x] Undo removes text objects or strokes
- [x] Clear removes all strokes and text objects
- [x] Mode switching (pen → A → pointer) works smoothly

## Related
- Closes #78
- Web follow-up: [shareddrawingweb#20](https://github.com/nicechester/shareddrawingweb/issues/20)