### PR TITLE
Fix: Persist Google Sign-In email across app launches

### DIFF
--- a/SharedDrawing.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SharedDrawing.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ec50f426d1493845e17ec6adf28b9e4af6dc5933c542f1abbcb4681a5e8cb2eb",
+  "originHash" : "e61e41469a54319ef0635a68f7394a5097f4b3a695eaa4c7d058b799e242c25a",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -44,15 +44,6 @@
       "state" : {
         "revision" : "dc39082d8881109d35b94b1c122164c0e8d08a55",
         "version" : "3.6.1"
-      }
-    },
-    {
-      "identity" : "google-mlkit-swiftpm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/d-date/google-mlkit-swiftpm",
-      "state" : {
-        "revision" : "7aefa43c5105f28b9a8f9a48f7a115524a101186",
-        "version" : "9.0.0"
       }
     },
     {

--- a/SharedDrawing/AuthService.swift
+++ b/SharedDrawing/AuthService.swift
@@ -34,6 +34,8 @@ class AuthService {
     var isAuthenticated: Bool { currentUserID != nil }
 
     private var authStateListener: AuthStateDidChangeListenerHandle?
+    private static let emailKey = "authServiceEmail"
+    private static let nameKey = "authServiceName"
 
     init() {
         setupAuthStateListener()
@@ -49,9 +51,8 @@ class AuthService {
         authStateListener = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             self?.currentUserID = user?.uid
             if let user = user {
-                self?.currentUserName = user.displayName
-                self?.currentUserEmail = user.email
-                // Check if user is anonymous
+                self?.currentUserName = user.displayName ?? UserDefaults.standard.string(forKey: Self.nameKey)
+                self?.currentUserEmail = user.email ?? UserDefaults.standard.string(forKey: Self.emailKey)
                 self?.isAnonymous = user.isAnonymous
             } else {
                 self?.currentUserName = nil
@@ -100,6 +101,7 @@ class AuthService {
                 currentUserID = anonUser.uid
                 currentUserName = result.user.profile?.givenName
                 currentUserEmail = result.user.profile?.email
+                persistUserData()
                 isAnonymous = false
             } catch let error as NSError where error.code == AuthErrorCode.credentialAlreadyInUse.rawValue {
                 // Credential already linked elsewhere, sign in normally
@@ -108,6 +110,7 @@ class AuthService {
                     currentUserID = firebaseUser.uid
                     currentUserName = firebaseUser.displayName
                     currentUserEmail = firebaseUser.email
+                    persistUserData()
                     isAnonymous = false
                 }
             }
@@ -118,6 +121,7 @@ class AuthService {
                 currentUserID = firebaseUser.uid
                 currentUserName = firebaseUser.displayName
                 currentUserEmail = firebaseUser.email
+                persistUserData()
                 isAnonymous = false
             }
         }
@@ -126,7 +130,18 @@ class AuthService {
     func signOut() async throws {
         GIDSignIn.sharedInstance.signOut()
         try Auth.auth().signOut()
+        UserDefaults.standard.removeObject(forKey: Self.emailKey)
+        UserDefaults.standard.removeObject(forKey: Self.nameKey)
         try await signInAnonymously()
+    }
+
+    private func persistUserData() {
+        if let email = currentUserEmail {
+            UserDefaults.standard.set(email, forKey: Self.emailKey)
+        }
+        if let name = currentUserName {
+            UserDefaults.standard.set(name, forKey: Self.nameKey)
+        }
     }
 
     static func topViewController() -> UIViewController? {

--- a/SharedDrawing/Features/Canvas/CanvasView.swift
+++ b/SharedDrawing/Features/Canvas/CanvasView.swift
@@ -592,7 +592,7 @@ struct CanvasView: View {
     }
 
     private func handleAddImageTapped() {
-        if viewModel.isAnonymous {
+        if viewModel.isAnonymous && authService.currentUserEmail == nil {
             showSignInPrompt = true
         } else {
             showImagePicker = true


### PR DESCRIPTION
## Summary
Persist user email and name to UserDefaults when signing in with Google, so they're available even after app restart or re-authentication. This ensures `currentUserEmail` remains set even if Firebase auth doesn't have the value stored.

## Changes
- Added email and name persistence to `AuthService`
- Updated auth state listener to restore from UserDefaults if Firebase doesn't have values
- Updated Google Sign-In flow to save user data
- Updated image picker logic in `CanvasView` to check `currentUserEmail` in addition to anonymous status

Fixes #102